### PR TITLE
Create dashboard view with progress rings

### DIFF
--- a/Stanford360.xcodeproj/project.pbxproj
+++ b/Stanford360.xcodeproj/project.pbxproj
@@ -156,6 +156,7 @@
 		4F8EA0B92D680A4400A94137 /* Activity */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Activity; sourceTree = "<group>"; };
 		4FA061CF2D4C4468008DE21A /* Views */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Views; sourceTree = "<group>"; };
 		4FF18DDD2D5FAB5E00E13832 /* ActivityTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ActivityTests; sourceTree = "<group>"; };
+		C1C1E6432D6E9A25007D38F0 /* Dashboard */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Dashboard; sourceTree = "<group>"; };
 		C1EFB0572D52F8E8008A6669 /* Hydration */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Hydration; sourceTree = "<group>"; };
 		C1EFB0682D52FA2C008A6669 /* Protein */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Protein; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -305,6 +306,7 @@
 		653A254F283387FE005D4D48 /* Stanford360 */ = {
 			isa = PBXGroup;
 			children = (
+				C1C1E6432D6E9A25007D38F0 /* Dashboard */,
 				C13ED86A2D656A0400033A55 /* Feed */,
 				4FA061CF2D4C4468008DE21A /* Views */,
 				4F8EA0B92D680A4400A94137 /* Activity */,
@@ -407,6 +409,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				4F8EA0B92D680A4400A94137 /* Activity */,
+				C1C1E6432D6E9A25007D38F0 /* Dashboard */,
 				C1EFB0572D52F8E8008A6669 /* Hydration */,
 				C1EFB0682D52FA2C008A6669 /* Protein */,
 			);

--- a/Stanford360/Dashboard/Models/Patient.swift
+++ b/Stanford360/Dashboard/Models/Patient.swift
@@ -1,0 +1,18 @@
+//
+//  Patient.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/25/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+struct Patient {
+	var activityMinutes: Int
+	var hydrationOunces: Double
+	var proteinGrams: Int
+}

--- a/Stanford360/Dashboard/Models/PatientManager.swift
+++ b/Stanford360/Dashboard/Models/PatientManager.swift
@@ -1,0 +1,21 @@
+//
+//  PatientManager.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/25/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+@Observable
+class PatientManager {
+	var patient: Patient
+	
+	init(patient: Patient = Patient(activityMinutes: 0, hydrationOunces: 0, proteinGrams: 0)) {
+		self.patient = patient
+	}
+}

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -1,0 +1,63 @@
+//
+//  DashboardView.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/25/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct DashboardView: View {
+	@Environment(PatientManager.self) private var patientManager
+	
+	var body: some View {
+		let patient = patientManager.patient
+		
+		VStack {
+			Text("Today's Progress")
+				.font(.largeTitle)
+				.bold()
+				.padding(.bottom, 40)
+			
+			Text("Activity")
+				.font(.title2)
+				.fontWeight(.light)
+			Text("\(patient.activityMinutes)/60")
+				.font(.title)
+				.fontWeight(.semibold)
+				.foregroundColor(.red)
+			Spacer()
+			
+			Text("Hydration")
+				.font(.title2)
+				.fontWeight(.light)
+			Text("\(patient.hydrationOunces, specifier: "%.2f")/60")
+				.font(.title)
+				.fontWeight(.semibold)
+				.foregroundColor(.blue)
+			Spacer()
+			
+			Text("Protein")
+				.font(.title2)
+				.fontWeight(.light)
+			Text("\(patient.proteinGrams)/60")
+				.font(.title)
+				.fontWeight(.semibold)
+				.foregroundColor(.green)
+			
+			ProgressRings()
+		}
+		.padding(.top, 20)
+	}
+}
+
+#Preview {
+	@Previewable @State var patientManager = PatientManager(patient: Patient(activityMinutes: 50, hydrationOunces: 40, proteinGrams: 10))
+	
+	DashboardView()
+		.environment(patientManager)
+}

--- a/Stanford360/Dashboard/Views/PercentageRing.swift
+++ b/Stanford360/Dashboard/Views/PercentageRing.swift
@@ -1,0 +1,162 @@
+//
+//  ActivityRing.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/26/25.
+//	Inspired by Frank Gia https://medium.com/@frankjia/creating-activity-rings-in-swiftui-11ef7d336676
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct PercentageRing: View {
+	private static let ShadowColor: Color = .black.opacity(0.2)
+	private static let ShadowRadius: CGFloat = 5
+	private static let ShadowOffsetMultiplier: CGFloat = ShadowRadius + 2
+	
+	private let ringWidth: CGFloat
+	private let percent: Double
+	private let backgroundColor: Color
+	private let foregroundColors: [Color]
+	private let startAngle: Double = -90
+	private let icon: Image?
+	private let iconSize: CGFloat
+	
+	private var gradientStartAngle: Double {
+		self.percent >= 100 ? relativePercentageAngle - 360 : startAngle
+	}
+	
+	private var absolutePercentageAngle: Double {
+		RingShape.percentToAngle(percent: self.percent, startAngle: 0)
+	}
+	private var relativePercentageAngle: Double {
+		// Take into account the startAngle
+		absolutePercentageAngle + startAngle
+	}
+	
+	private var lastGradientColor: Color {
+		self.foregroundColors.last ?? .black
+	}
+	
+	private var ringGradient: AngularGradient {
+		AngularGradient(
+			gradient: Gradient(colors: self.foregroundColors),
+			center: .center,
+			startAngle: Angle(degrees: self.gradientStartAngle),
+			endAngle: Angle(degrees: relativePercentageAngle)
+		)
+	}
+	
+	var body: some View {
+		// Wrap view in a GeometryReader so that the view has access to its parent size
+		GeometryReader { geometry in
+			ZStack {
+				// background ring
+				RingShape()
+					.stroke(style: StrokeStyle(lineWidth: self.ringWidth))
+					.fill(self.backgroundColor)
+				
+				// foreground ring
+				RingShape(percent: self.percent, startAngle: self.startAngle)
+					.stroke(style: StrokeStyle(lineWidth: self.ringWidth, lineCap: .round))
+					.fill(self.ringGradient)
+				
+				// shadow to show progress for percentages over 100%
+				if self.getShowShadow(frame: geometry.size) {
+					Circle()
+						.fill(self.lastGradientColor)
+						.frame(width: self.ringWidth, height: self.ringWidth, alignment: .center)
+						.offset(
+							x: self.getEndCircleLocation(frame: geometry.size).0,
+							y: self.getEndCircleLocation(frame: geometry.size).1
+						)
+						.shadow(
+							color: PercentageRing.ShadowColor,
+							radius: PercentageRing.ShadowRadius,
+							x: self.getEndCircleShadowOffset().0,
+							y: self.getEndCircleShadowOffset().1
+						)
+				}
+				
+				// add icon at the end of the ring if provided
+				if let icon = self.icon {
+					icon
+						.resizable()
+						.aspectRatio(contentMode: .fit)
+						.frame(width: self.iconSize, height: self.iconSize)
+						.foregroundColor(.white)
+						.offset(
+							x: self.getEndCircleLocation(frame: geometry.size).0,
+							y: self.getEndCircleLocation(frame: geometry.size).1
+						)
+						.zIndex(1)
+				}
+			}
+		}
+		// Padding to ensure that the entire ring fits within the view size allocated
+		.padding(self.ringWidth / 2)
+	}
+	
+	init(ringWidth: CGFloat, percent: Double, backgroundColor: Color, foregroundColors: [Color], icon: Image? = nil, iconSize: CGFloat = 24) {
+		self.ringWidth = ringWidth
+		self.percent = percent
+		self.backgroundColor = backgroundColor
+		self.foregroundColors = foregroundColors
+		self.icon = icon
+		self.iconSize = iconSize
+	}
+	
+	// Returns the (x, y) location of the offset
+	private func getEndCircleLocation(frame: CGSize) -> (CGFloat, CGFloat) {
+		// Get angle of the end circle with respect to the start angle
+		let angleOfEndInRadians: Double = relativePercentageAngle.toRadians()
+		let offsetRadius = min(frame.width, frame.height) / 2
+		return (offsetRadius * cos(angleOfEndInRadians).toCGFloat(),
+				offsetRadius * sin(angleOfEndInRadians).toCGFloat())
+	}
+	
+	private func getEndCircleShadowOffset() -> (CGFloat, CGFloat) {
+		let angleForOffset = absolutePercentageAngle + (self.startAngle + 90)
+		let angleForOffsetInRadians = angleForOffset.toRadians()
+		let relativeXOffset = cos(angleForOffsetInRadians)
+		let relativeYOffset = sin(angleForOffsetInRadians)
+		let xOffset = relativeXOffset.toCGFloat() * PercentageRing.ShadowOffsetMultiplier
+		let yOffset = relativeYOffset.toCGFloat() * PercentageRing.ShadowOffsetMultiplier
+		return (xOffset, yOffset)
+	}
+	
+	private func getShowShadow(frame: CGSize) -> Bool {
+		let circleRadius = min(frame.width, frame.height) / 2
+		let remainingAngleInRadians = (360 - absolutePercentageAngle).toRadians().toCGFloat()
+		if self.percent >= 100 {
+			return true
+		} else if circleRadius * remainingAngleInRadians <= self.ringWidth {
+			return true
+		}
+		
+		return false
+	}
+}
+
+extension Double {
+	func toRadians() -> Double {
+		self * Double.pi / 180
+	}
+	func toCGFloat() -> CGFloat {
+		CGFloat(self)
+	}
+}
+
+#Preview {
+	PercentageRing(
+		ringWidth: 50,
+		percent: 100,
+		backgroundColor: Color.green.opacity(0.2),
+		foregroundColors: [Color.green, Color(red: 0, green: 0.7, blue: 0)],
+		icon: Image(systemName: "figure.walk"),
+		iconSize: 28
+	)
+}

--- a/Stanford360/Dashboard/Views/ProgressRings.swift
+++ b/Stanford360/Dashboard/Views/ProgressRings.swift
@@ -1,0 +1,69 @@
+//
+//  ProgressRings.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/26/25.
+//	Inspired by Frank Gia https://medium.com/@frankjia/creating-activity-rings-in-swiftui-11ef7d336676
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct ProgressRings: View {
+	@Environment(PatientManager.self) private var patientManager
+	
+	private let ringWidth: CGFloat = 50
+	private let iconSize: CGFloat = 30
+	
+	var body: some View {
+		let patient = patientManager.patient
+		
+		ZStack {
+			// activity ring
+			PercentageRing(
+				ringWidth: ringWidth,
+				percent: Double(patient.activityMinutes) / 60 * 100,
+				backgroundColor: Color.red.opacity(0.4),
+				foregroundColors: [Color.red, Color(red: 0.75, green: 0, blue: 0)],
+				icon: Image(systemName: "figure.walk"),
+				iconSize: iconSize
+			)
+			.padding(20)
+			.accessibilityLabel("Activity Progress")
+			
+			// hydration ring
+			PercentageRing(
+				ringWidth: ringWidth,
+				percent: Double(patient.hydrationOunces) / 60 * 100,
+				backgroundColor: Color.blue.opacity(0.4),
+				foregroundColors: [Color.blue, Color(red: 0, green: 0, blue: 0.75)],
+				icon: Image(systemName: "drop.fill"),
+				iconSize: iconSize
+			)
+			.padding(70)
+			.accessibilityLabel("Hydration Progress")
+			
+			// protein ring
+			PercentageRing(
+				ringWidth: ringWidth,
+				percent: Double(patient.proteinGrams) / 60 * 100,
+				backgroundColor: Color.green.opacity(0.4),
+				foregroundColors: [Color.green, Color(red: 0, green: 0.75, blue: 0)],
+				icon: Image(systemName: "fork.knife"),
+				iconSize: iconSize
+			)
+			.padding(120)
+			.accessibilityLabel("Protein Progress")
+		}
+	}
+}
+
+#Preview {
+	@Previewable @State var patientManager = PatientManager(patient: Patient(activityMinutes: 30, hydrationOunces: 40, proteinGrams: 10))
+	
+	ProgressRings()
+		.environment(patientManager)
+}

--- a/Stanford360/Dashboard/Views/RingShape.swift
+++ b/Stanford360/Dashboard/Views/RingShape.swift
@@ -1,0 +1,66 @@
+//
+//  RingShape.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 2/26/25.
+//	Inspired by Frank Gia https://medium.com/@frankjia/creating-activity-rings-in-swiftui-11ef7d336676
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct RingShape: Shape {
+	private var percent: Double
+	private var startAngle: Double
+	private let drawnClockwise: Bool
+	
+	// 2. This allows animations to run smoothly for percent values
+	var animatableData: Double {
+		get {
+			percent
+		}
+		set {
+			percent = newValue
+		}
+	}
+	
+	init(percent: Double = 100, startAngle: Double = -90, drawnClockwise: Bool = false) {
+		self.percent = percent
+		self.startAngle = startAngle
+		self.drawnClockwise = drawnClockwise
+	}
+	
+	// helper function to convert percent values to angles in degrees
+	static func percentToAngle(percent: Double, startAngle: Double) -> Double {
+		(percent / 100 * 360) + startAngle
+	}
+	
+	// this draws a simple arc from the start angle to the end angle
+	func path(in rect: CGRect) -> Path {
+		let width = rect.width
+		let height = rect.height
+		let radius = min(width, height) / 2
+		let center = CGPoint(x: width / 2, y: height / 2)
+		let endAngle = Angle(degrees: RingShape.percentToAngle(percent: self.percent, startAngle: self.startAngle))
+		
+		return Path { path in
+			path.addArc(
+				center: center,
+				radius: radius,
+				startAngle: Angle(degrees: startAngle),
+				endAngle: endAngle,
+				clockwise: drawnClockwise
+			)
+		}
+	}
+}
+
+#Preview {
+	RingShape(percent: 60, startAngle: -90, drawnClockwise: false)
+		.stroke(style: StrokeStyle(lineWidth: 50, lineCap: .round))
+		.fill(Color.black)
+		.frame(width: 300, height: 300)
+}

--- a/Stanford360/HomeView.swift
+++ b/Stanford360/HomeView.swift
@@ -17,6 +17,7 @@ struct HomeView: View {
         case hydration
 		case protein
 		case activity
+		case dashboard
     }
 
     @AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.home
@@ -36,10 +37,12 @@ struct HomeView: View {
                 ActivityView()
             }
             .customizationID("home.activity")
+			
             Tab("Hydration", systemImage: "drop.fill", value: .hydration) {
                 HydrationTrackerView()
             }
-                .customizationID("home.hydration")
+			.customizationID("home.hydration")
+			
             Tab("Protein", systemImage: "fork.knife", value: .protein) {
                 ProteinContentView(proteinData: ProteinIntakeModel(
 //                    userID: "defaultUser",
@@ -47,9 +50,13 @@ struct HomeView: View {
                     meals: []
                 ))
             }
-                .customizationID("home.protein")
+			.customizationID("home.protein")
+			
+			Tab("Dashboard", systemImage: "target", value: .dashboard) {
+				DashboardView()
+			}
+			.customizationID("home.dashboard")
         }
-        
         .task {
             activityManager.sendActivityReminder()
         }


### PR DESCRIPTION
# *Create dashboard view with progress rings*

## :recycle: Current situation & Problem
Currently, patients can see their progress and adherence to the 60-60-60 rule on the respective tabs; however, there is no way for the patient to see their progress in a single unified view.


## :gear: Release Notes 
This PR creates a "dashboard" view, allowing the patient to see their progress and adherence to the 60-60-60 rule in a single unified view.
- Creates a `Patient` model and `PatientManager` class
- Creates a `ProgressRings` component to visualize the patient's progress and adhere to the 60-60-60 rule
- Creates a `DashboardView` to display the progress rings and relevant details

At the moment, the `DashboardView`'s data is static since the patient model is not yet connected to the rest of the app. In a follow-up PR, we will use the patient manager to retrieve the activity minutes, hydration ounces, and protein grams from the respective models' managers and update the patient accordingly such that the `DashboardView`'s data is dynamic.

The design is also a preliminary one and will be iterated on and improved upon in follow-up PRs.

## :books: Documentation
<img width="334" alt="Screenshot 2025-02-26 at 5 01 04 AM" src="https://github.com/user-attachments/assets/de157645-cbec-4b94-9931-e47743b1208a" />


## :white_check_mark: Testing
We will add tests later as they have currently been blocking our CI checks despite passing locally


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
