### PR TITLE
Connect all views to patient dashboard

### DIFF
--- a/Stanford360/Activity/View/AddActivitySheetView.swift
+++ b/Stanford360/Activity/View/AddActivitySheetView.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct AddActivitySheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(Stanford360Standard.self) private var standard
+	@Environment(PatientManager.self) private var patientManager
     @Bindable var activityManager: ActivityManager
     @State private var activeMinutes = ""
     @State private var selectedActivity = "Walking 🚶‍♂️"
@@ -145,6 +146,7 @@ struct AddActivitySheet: View {
         )
         
         activityManager.logActivityToView(newActivity)
+		patientManager.updateActivityMinutes(activityManager.todayTotalMinutes)
         try? await standard.store(activity: newActivity)
         dismiss()
     }

--- a/Stanford360/Dashboard/Models/Patient.swift
+++ b/Stanford360/Dashboard/Models/Patient.swift
@@ -14,5 +14,5 @@ import Foundation
 struct Patient {
 	var activityMinutes: Int
 	var hydrationOunces: Double
-	var proteinGrams: Int
+	var proteinGrams: Double
 }

--- a/Stanford360/Dashboard/Models/PatientManager.swift
+++ b/Stanford360/Dashboard/Models/PatientManager.swift
@@ -12,10 +12,23 @@
 import Foundation
 import Spezi
 
+@Observable
 class PatientManager: Module, EnvironmentAccessible {
-	@Published var patient: Patient
+	var patient: Patient
 	
 	init(patient: Patient = Patient(activityMinutes: 0, hydrationOunces: 0, proteinGrams: 0)) {
 		self.patient = patient
+	}
+	
+	func updateActivityMinutes(_ minutes: Int) {
+		self.patient.activityMinutes = minutes
+	}
+	
+	func updateHydrationOunces(_ ounces: Double) {
+		self.patient.hydrationOunces = ounces
+	}
+	
+	func updateProteinGrams(_ grams: Double) {
+		self.patient.proteinGrams = grams
 	}
 }

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -44,7 +44,7 @@ struct DashboardView: View {
 			Text("Protein")
 				.font(.title2)
 				.fontWeight(.light)
-			Text("\(patient.proteinGrams)/60")
+			Text("\(patient.proteinGrams, specifier: "%.2f")/60")
 				.font(.title)
 				.fontWeight(.semibold)
 				.foregroundColor(.green)

--- a/Stanford360/Hydration/Model/HydrationTrackerViewAction.swift
+++ b/Stanford360/Hydration/Model/HydrationTrackerViewAction.swift
@@ -52,6 +52,7 @@ extension HydrationTrackerView {
             await updateFirestoreLog(newTotalIntake, newStreak, isStreakUpdated, lastHydrationDate)
 
             totalIntake = newTotalIntake
+			patientManager.updateHydrationOunces(newTotalIntake)
             streak = newStreak
             
             let updatedWeeklyData = await standard.fetchWeeklyHydrationData()
@@ -116,6 +117,7 @@ extension HydrationTrackerView {
 
             if let log = fetchedLog, calendar.isDate(log.lastHydrationDate, inSameDayAs: today) {
                 totalIntake = log.amountOz
+				patientManager.updateHydrationOunces(log.amountOz)
                 streak = log.streak
             }
 

--- a/Stanford360/Hydration/View/HydrationTrackerView.swift
+++ b/Stanford360/Hydration/View/HydrationTrackerView.swift
@@ -15,6 +15,8 @@ struct HydrationTrackerView: View {
         case week
         case month
     }
+	
+	@Environment(PatientManager.self) var patientManager
 
     // MARK: - State
     @State var intakeAmount: String = ""

--- a/Stanford360/Protein/View/AddMealView.swift
+++ b/Stanford360/Protein/View/AddMealView.swift
@@ -13,6 +13,7 @@ struct AddMealView: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var proteinData: ProteinIntakeModel
     @Environment(Stanford360Standard.self) private var standard
+	@Environment(PatientManager.self) private var patientManager
     
     @State private var mealName: String = ""
     @State private var proteinAmount: Double = 0.0
@@ -145,6 +146,7 @@ struct AddMealView: View {
                 Task {
                     await saveMeal()
                 }
+				patientManager.updateProteinGrams(proteinData.totalProteinGrams)
             }
         }) {
             Text("Save Meal")


### PR DESCRIPTION
# *Connect all views to patient dashboard*

## :recycle: Current situation & Problem
This is a follow-up PR to: 
1. [Create dashboard view with progress rings](https://github.com/CS342/2025-Stanford-360/pull/21)
2. [Turn `PatientManager` into Spezi Module](https://github.com/CS342/2025-Stanford-360/pull/22)


Currently, the DashboardView's data is static since the patient model is not yet connected to the rest of the app. This means that updates to the patient's activity, hydration, or protein in their respective tabs do not reflect in the dashboard.


## :gear: Release Notes 
* Uses the `PatientManager` Module to retrieve the day's activity minutes, hydration ounces, and protein grams from the respective models' views
* Updates the DashboardView's data accordingly
<img width="377" alt="Screenshot 2025-02-28 at 12 56 09 PM" src="https://github.com/user-attachments/assets/80995d67-32d3-4634-bd45-8cb07cf13e14" />

In more follow-up PRs, we will:
* Fetch the data from Firestore on initial load of the Dashboard View, such that it does not rely on the other views to fetch data first
* Continue to iterate on and improve the UI

## :books: Documentation
N/A


## :white_check_mark: Testing
Testing was done locally. Written tests are on pause until we understand what is causing them to pass locally but break in the CI.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
