### PR TITLE
finished hydration notification

### DIFF
--- a/Stanford360/Hydration/Model/HydrationScheduler.swift
+++ b/Stanford360/Hydration/Model/HydrationScheduler.swift
@@ -1,0 +1,74 @@
+//
+// This source file is part of the Stanford 360 based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import Spezi
+import SpeziScheduler
+import SpeziViews
+import UserNotifications
+
+@Observable
+final class HydrationScheduler: Module, DefaultInitializable, EnvironmentAccessible {
+    @Dependency(Scheduler.self) @ObservationIgnored private var scheduler
+
+    @MainActor var viewState: ViewState = .idle
+
+    init() {}
+
+    func configure() {
+        do {
+            try scheduler.createOrUpdateTask(
+                id: "hydration-reminder",
+                title: "💧 Stay Hydrated!",
+                instructions: "You haven't logged any water intake in the last 4 hours. Drink up!",
+                category: Task.Category(rawValue: "Hydration"),
+                schedule: .daily(hour: 9, minute: 0, startingAt: .today), // First reminder at 9 AM
+                scheduleNotifications: true
+            )
+        } catch {
+            viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create hydration reminder."))
+        }
+    }
+
+    // MARK: - Called when the user logs water intake to reschedule reminders.
+    @MainActor
+    func userLoggedWaterIntake() async {
+        let now = Date()
+        let calendar = Calendar.current
+        let hour = calendar.component(.hour, from: now)
+        
+        // If it's after 9 PM, don't schedule new reminders
+        if hour >= 21 {
+            print("⏳ Skipping hydration reminder after 9 PM.")
+            return
+        }
+
+        // If it's before 9 AM, also skip scheduling
+        if hour < 9 {
+            print("⏳ Skipping hydration reminder before 9 AM.")
+            return
+        }
+        
+        // Schedule a new reminder
+        do {
+            try scheduler.createOrUpdateTask(
+                id: "hydration-reminder",
+                title: "💧 Stay Hydrated!",
+                instructions: "You haven't logged any water intake in the last 4 hours. Drink up!",
+                category: Task.Category(rawValue: "Hydration"),
+                schedule: .daily(
+                    hour: Calendar.current.component(.hour, from: now) + 4,
+                    minute: Calendar.current.component(.minute, from: now),
+                    startingAt: .now
+                ),
+                scheduleNotifications: true
+            )
+        } catch {
+        }
+    }
+}

--- a/Stanford360/Hydration/Model/HydrationTrackerViewAction.swift
+++ b/Stanford360/Hydration/Model/HydrationTrackerViewAction.swift
@@ -62,7 +62,7 @@ extension HydrationTrackerView {
                 monthlyData = updatedMonthlyData
             }
             
-            scheduleHydrationReminder()
+            await hydrationScheduler.userLoggedWaterIntake()
             
             displayMilestoneMessage(newTotalIntake: newTotalIntake, lastMilestone: fetchedLog?.lastTriggeredMilestone ?? 0)
         } catch {
@@ -147,20 +147,5 @@ extension HydrationTrackerView {
         }
 
         return (latestMessage, isSpecialMilestone)
-    }
-    
-    // MARK: - Hydration Reminder Notifications
-    func scheduleHydrationReminder() {
-        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["hydrationReminder"])
-
-        let content = UNMutableNotificationContent()
-        content.title = "💧 Stay Hydrated!"
-        content.body = "You haven't logged any water intake in the last 4 hours. Drink up!"
-        content.sound = .default
-
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 4 * 60 * 60, repeats: false)
-        let request = UNNotificationRequest(identifier: "hydrationReminder", content: content, trigger: trigger)
-
-        UNUserNotificationCenter.current().add(request)
     }
 }

--- a/Stanford360/Hydration/View/HydrationTrackerView.swift
+++ b/Stanford360/Hydration/View/HydrationTrackerView.swift
@@ -17,6 +17,8 @@ struct HydrationTrackerView: View {
     }
 	
 	@Environment(PatientManager.self) var patientManager
+    @Environment(Stanford360Standard.self) var standard
+    @Environment(HydrationScheduler.self) var hydrationScheduler
 
     // MARK: - State
     @State var intakeAmount: String = ""
@@ -40,8 +42,6 @@ struct HydrationTrackerView: View {
         max(100, weeklyData.map { $0.intakeOz }.max() ?? 0)
     }
 
-    @Environment(Stanford360Standard.self) var standard
-
     // MARK: - Preset Amounts
     let presetAmounts: [(icon: String, amount: Double)] = [
         (icon: "small_mug", amount: 8.0),
@@ -55,14 +55,6 @@ struct HydrationTrackerView: View {
     // MARK: - Body
     var body: some View {
         ZStack {
-            /*
-            LinearGradient(
-                gradient: Gradient(colors: [Color.blue.opacity(0.2), Color.white]),
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .edgesIgnoringSafeArea(.all)
-             */
             ScrollView {
                 VStack(spacing: 20) {
                     headerView()

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -63,6 +63,9 @@
     "💧 Hydration Tracker" : {
 
     },
+    "💧 Stay Hydrated!" : {
+
+    },
     "2 of 3 Meals" : {
 
     },
@@ -748,6 +751,9 @@
 
     },
     "You have reached the first 30-gram of protein goal🎉. You need %@ gram more to reach your goal!💪" : {
+
+    },
+    "You haven't logged any water intake in the last 4 hours. Drink up!" : {
 
     },
     "You need %@ oz more to reach your goal!" : {

--- a/Stanford360/Stanford360Delegate.swift
+++ b/Stanford360/Stanford360Delegate.swift
@@ -56,6 +56,7 @@ class Stanford360Delegate: SpeziAppDelegate {
 			
 			Stanford360Scheduler()
 			Scheduler()
+            HydrationScheduler()
 			OnboardingDataSource()
 			Notifications()
 			PatientManager()


### PR DESCRIPTION
# *Hydration Notification*

## :recycle: Current situation & Problem
*The hydration reminder system lacked functionality to schedule notification reminder.*
This PR resolves these issues by:
- Scheduling a daily reminder at 9 AM.
- Adjusting the reminder dynamically so that if the user logs water intake, a new reminder is scheduled exactly 4 hours later.
- Preventing reminders between 9 PM and 9 AM to avoid unnecessary notifications at night.


## :gear: Release Notes 
- Feature: Hydration reminders dynamically adjust based on user activity.
- Feature: A daily reminder is set at 9 AM.
- Feature: If no intake occurs, a new reminder is set 4 hours after the last intake.
- Feature: No reminders are sent between 9 PM - 9 AM.
- Improvement: Uses createOrUpdateTask to automatically replace previous reminders.


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
