### PR TITLE
add account to toolbar of activity and protein

### DIFF
--- a/Stanford360.xcodeproj/xcshareddata/xcschemes/Stanford360.xcscheme
+++ b/Stanford360.xcodeproj/xcshareddata/xcschemes/Stanford360.xcscheme
@@ -83,11 +83,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--showOnboarding"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--skipOnboarding"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testSchedule"

--- a/Stanford360/Activity/View/ActivityView.swift
+++ b/Stanford360/Activity/View/ActivityView.swift
@@ -10,6 +10,7 @@
 
 import Charts
 import FirebaseAuth
+@_spi(TestingSupport) import SpeziAccount
 import SwiftUI
 
 /// Simple UI for tracking kids' activity.
@@ -22,11 +23,13 @@ struct ActivityView: View {
     @Environment(ActivityManager.self) private var activityManager
     @Environment(HealthKitManager.self) private var healthKitManager
 	@Environment(PatientManager.self) private var patientManager
+    @Environment(Account.self) private var account: Account?
 	
 	// State properties grouped together
     @State private var showingAddActivity = false
     @State private var selectedTimeFrame: TimeFrame = .today
     @State private var showHealthKitAlert = false
+    @Binding private var presentingAccount: Bool
     
     @Environment(Stanford360Standard.self) internal var standard
 
@@ -69,6 +72,11 @@ struct ActivityView: View {
         .sheet(isPresented: $showingAddActivity) {
             AddActivitySheet()
         }
+        .toolbar {
+            if account != nil {
+                AccountButton(isPresented: $presentingAccount)
+            }
+        }
         .alert("HealthKit Access Required", isPresented: $showHealthKitAlert) {
             Button("Open Settings", role: .none) {
                 if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
@@ -93,7 +101,6 @@ struct ActivityView: View {
         }
         .padding()
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, 16)
         .background(Color.orange.opacity(0.1))
         .cornerRadius(10)
         .onTapGesture {
@@ -143,6 +150,10 @@ struct ActivityView: View {
         }
     }
     
+    init(presentingAccount: Binding<Bool>) {
+        self._presentingAccount = presentingAccount
+    }
+    
     // Retrieve data from HealthKit and convert it to an Activity
     func syncHealthKitData() async {
         do {
@@ -181,6 +192,8 @@ struct ActivityView: View {
 }
 
 #Preview {
-    ActivityView()
+    @Previewable @State var presentingAccount = false
+
+    ActivityView(presentingAccount: $presentingAccount)
         .environment(Stanford360Standard())
 }

--- a/Stanford360/Contacts/Contacts.swift
+++ b/Stanford360/Contacts/Contacts.swift
@@ -54,7 +54,6 @@ struct Contacts: View {
 
     @Binding var presentingAccount: Bool
     
-    
     var body: some View {
         NavigationStack {
             ContactsList(contacts: contacts)
@@ -66,7 +65,6 @@ struct Contacts: View {
                 }
         }
     }
-    
     
     init(presentingAccount: Binding<Bool>) {
         self._presentingAccount = presentingAccount

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -9,6 +9,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@_spi(TestingSupport) import SpeziAccount
 import SwiftUI
 
 struct DashboardView: View {
@@ -17,6 +18,8 @@ struct DashboardView: View {
 	@Environment(ActivityManager.self) private var activityManager
 	@Environment(HydrationManager.self) private var hydrationManager
 	@Environment(ProteinManager.self) private var proteinManager
+	@Environment(Account.self) private var account: Account?
+	@Binding private var presentingAccount: Bool
 	
 	var body: some View {
 		let patient = patientManager.patient
@@ -51,10 +54,19 @@ struct DashboardView: View {
 			}
 			.padding(.horizontal, 20)
 		}
+		.toolbar {
+			if account != nil {
+				AccountButton(isPresented: $presentingAccount)
+			}
+		}
 		.task {
 			await loadPatientData()
 		}
 	}
+
+	init(presentingAccount: Binding<Bool>) {
+        self._presentingAccount = presentingAccount
+    }
 	
 	/// Loads the patient's activities, hydration, and meals into their respective managers and updates the patient's data accordingly
 	func loadPatientData() async {
@@ -76,6 +88,7 @@ struct DashboardView: View {
 
 #Preview {
 	@Previewable @State var standard = Stanford360Standard()
+	@Previewable @State var presentingAccount = false
 	
 	@Previewable @State var patientManager = PatientManager(patient: Patient(
 		activityMinutes: 50,
@@ -89,7 +102,7 @@ struct DashboardView: View {
 	
 	@Previewable @State var proteinManager = ProteinManager()
 	
-	DashboardView()
+	DashboardView(presentingAccount: $presentingAccount)
 		.environment(standard)
 		.environment(patientManager)
 		.environment(activityManager)

--- a/Stanford360/HomeView.swift
+++ b/Stanford360/HomeView.swift
@@ -34,22 +34,22 @@ struct HomeView: View {
 			.customizationID("home.home")
 			
 			Tab("Activity", systemImage: "figure.walk", value: .activity) {
-				ActivityView()
+				ActivityView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.activity")
 			
 			Tab("Hydration", systemImage: "drop.fill", value: .hydration) {
-				HydrationTrackerView()
+				HydrationTrackerView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.hydration")
 			
 			Tab("Protein", systemImage: "fork.knife", value: .protein) {
-                ProteinTrackerView()
+                ProteinTrackerView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.protein")
 			
 			Tab("Dashboard", systemImage: "target", value: .dashboard) {
-				DashboardView()
+				DashboardView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.dashboard")
 		}

--- a/Stanford360/Hydration/View/HydrationTrackerView.swift
+++ b/Stanford360/Hydration/View/HydrationTrackerView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@_spi(TestingSupport) import SpeziAccount
 import SwiftUI
 
 struct HydrationTrackerView: View {
@@ -41,6 +42,8 @@ struct HydrationTrackerView: View {
     var maxWeeklyIntake: Double {
         max(100, weeklyData.map { $0.intakeOz }.max() ?? 0)
     }
+    @Environment(Account.self) private var account: Account?
+    @Binding private var presentingAccount: Bool
 
     // MARK: - Preset Amounts
     let presetAmounts: [(icon: String, amount: Double)] = [
@@ -72,6 +75,11 @@ struct HydrationTrackerView: View {
                 }
                 .padding(.top, 30)
                 .frame(maxHeight: .infinity, alignment: .top)
+                .toolbar {
+                    if account != nil {
+                        AccountButton(isPresented: $presentingAccount)
+                    }
+                }
             }
             .onAppear {
                 Task {
@@ -87,6 +95,10 @@ struct HydrationTrackerView: View {
         }
     }
     
+    init(presentingAccount: Binding<Bool>) {
+        self._presentingAccount = presentingAccount
+    }
+
     func hydrationPeriodPicker() -> some View {
         Picker("Hydration Period", selection: $selectedTimeFrame) {
             Text("Today").tag(HydrationTimeFrame.today)
@@ -100,6 +112,8 @@ struct HydrationTrackerView: View {
 
 // MARK: - Preview
 #Preview {
-    HydrationTrackerView()
+    @Previewable @State var presentingAccount = false
+
+    HydrationTrackerView(presentingAccount: $presentingAccount)
         .environment(Stanford360Standard())
 }

--- a/Stanford360/Protein/View/ProteinTrackerView.swift
+++ b/Stanford360/Protein/View/ProteinTrackerView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+@_spi(TestingSupport) import SpeziAccount
 import SwiftUI
 
 struct ProteinTrackerView: View {
@@ -18,6 +19,8 @@ struct ProteinTrackerView: View {
     @Environment(Stanford360Standard.self) private var standard
     @Environment(ProteinManager.self) private var proteinManager
     @State private var selectedTimeFrame: ProteinTimeFrame = .today
+    @Environment(Account.self) private var account: Account?
+	@Binding private var presentingAccount: Bool
     
     var body: some View {
         NavigationStack {
@@ -47,12 +50,17 @@ struct ProteinTrackerView: View {
                 addProteinButton
             }
             .task { await loadMeals() } // Load meals when the view appears
+            .toolbar {
+                if account != nil {
+                    AccountButton(isPresented: $presentingAccount)
+                }
+            }
         }
         .sheet(isPresented: $showingAddProtein) {
             AddMealView()
         }
     }
-    
+
     // MARK: - Floating Add Protein Button (Fixed at the bottom)
     private var addProteinButton: some View {
         VStack {
@@ -72,6 +80,10 @@ struct ProteinTrackerView: View {
         }
     }
     
+    init(presentingAccount: Binding<Bool>) {
+        self._presentingAccount = presentingAccount
+    }
+    
     // MARK: - Header
     func headerView() -> some View {
         Text("🍗 Protein Tracker")
@@ -81,7 +93,7 @@ struct ProteinTrackerView: View {
             .multilineTextAlignment(.center) // Ensures center alignment for multiline text
             .padding(.top)
     }
-
+    
     
     // MARK: - Time Frame Picker
     func proteinPeriodPicker() -> some View {
@@ -190,6 +202,7 @@ struct ProteinTrackerView: View {
 
 #if DEBUG
 #Preview {
-    ProteinTrackerView()
+	@Previewable @State var presentingAccount = false
+    ProteinTrackerView(presentingAccount: $presentingAccount)
 }
 #endif

--- a/Stanford360/Schedule/ScheduleView.swift
+++ b/Stanford360/Schedule/ScheduleView.swift
@@ -20,7 +20,6 @@ struct ScheduleView: View {
 
     @State private var presentedEvent: Event?
     @Binding private var presentingAccount: Bool
-
     
     var body: some View {
         @Bindable var scheduler = scheduler
@@ -45,7 +44,6 @@ struct ScheduleView: View {
                 }
         }
     }
-    
     
     init(presentingAccount: Binding<Bool>) {
         self._presentingAccount = presentingAccount


### PR DESCRIPTION
# :sparkles: Added Account Icon and Toolbar Access to Activity & Protein Views  

## :recycle: Current Situation & Problem  
Previously, users could not easily access their account details from the `Activity` and `Protein` views. This PR adds the **account icon** and integrates access into the toolbar for both views, allowing seamless navigation to the account details.  

## :gear: Release Notes  
### New Features:  
- **Added account icon** in the toolbar of the `Activity` and `Protein` views.  
- **Enabled account access** from both views, improving user experience and accessibility.  

## :books: Documentation  
- Updated the UI documentation to reflect the addition of the **account icon** and new **navigation functionality** in the `Activity` and `Protein` views.  
- This change aligns with user experience improvements and enhances navigation accessibility.  

## :white_check_mark: Testing  
TBD

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
