### PR TITLE
remove calories, edit/delete activity, add notifications

### DIFF
--- a/Stanford360/Activity/Model/Activity+StandardExtension.swift
+++ b/Stanford360/Activity/Model/Activity+StandardExtension.swift
@@ -25,35 +25,20 @@ import SpeziQuestionnaire
 import SwiftUI
 
 extension Stanford360Standard {
-	// /// Stores an activity document under the current user's subcollection "activities".
-	// @MainActor
-	// func store(activity: Activity) async throws {
-	//     if !FeatureFlags.disableFirebase {
-	//         // Get the user's document reference from your Firebase configuration.
-	//         let userDocRef = try await configuration.userDocumentReference
-	
-	//         // Create or access the "activities" subcollection under the user's document.
-	//         try userDocRef.collection("activities").addDocument(from: activity)
-	
-	//         // Optional: Log success
-	//         await logger.debug("Activity stored successfully for user \(userDocRef.documentID)")
-	//     }
-	// }
-	
-	/// Get activity document reference for a specific date and activity ID
+	/// Get activity document reference for a specific activity ID
 	private func activityDocument(activityId: String = UUID().uuidString) async throws -> DocumentReference {
 		let docRef = try await configuration.userDocumentReference
 		return docRef
 			.collection("activities")
 			.document(activityId)
 	}
-	
+
+	/// Adds a new activity to Firestore
 	func addActivityToFirestore(activity: Activity) async {
 		do {
 			let activityData: [String: Any] = [
 				"steps": activity.steps,
 				"activeMinutes": activity.activeMinutes,
-				"caloriesBurned": activity.caloriesBurned,
 				"activityType": activity.activityType,
 				"date": Timestamp(date: activity.date)
 			]
@@ -62,7 +47,6 @@ extension Stanford360Standard {
 			try await activityDocRef.setData(activityData, merge: true)
 			
 			logger.debug("Activity stored successfully")
-			await ActivityScheduler().userLoggedActivity()
 		} catch {
 			logger.error("Could not store activity: \(error)")
 		}
@@ -84,47 +68,39 @@ extension Stanford360Standard {
 		
 		return activities
 	}
-	
-	//    func fetchActivitiesInRange(from startDate: Date, to endDate: Date) async throws -> [Activity] {
-	//        do {
-	//            let calendar = Calendar.current
-	//            guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: endDate) else {
-	//                return []
-	//            }
-	//            
-	//            let activityDocRef = try await activityDocument(date: startDate)
-	//            print("✅ Fetching activities from \(startDate) to \(endDate)")
-	//            
-	//            let snapshot = try await activityDocRef
-	//                .collection("dailyActivities")
-	//                .whereField("date", isGreaterThanOrEqualTo: Timestamp(date: startDate))
-	//                .whereField("date", isLessThanOrEqualTo: Timestamp(date: endOfDay))
-	//                .getDocuments()
-	//            
-	//            let activities = snapshot.documents.compactMap { document -> Activity? in
-	//                let data = document.data()
-	//                // Extract each field safely
-	//                let date = (data["date"] as? Timestamp)?.dateValue() ?? startDate
-	//                let steps = data["steps"] as? Int ?? 0
-	//                let activeMinutes = data["activeMinutes"] as? Int ?? 0
-	//                let caloriesBurned = data["caloriesBurned"] as? Int ?? 0
-	//                let activityType = data["activityType"] as? String ?? "Unknown"
-	//                
-	//                return Activity(
-	//                    date: date,
-	//                    steps: steps,
-	//                    activeMinutes: activeMinutes,
-	//                    caloriesBurned: caloriesBurned,
-	//                    activityType: activityType,
-	//                    id: document.documentID
-	//                )
-	//            }
-	//            
-	//            print("✅ Found \(activities.count) activities")
-	//            return activities.sorted { $0.date > $1.date }
-	//        } catch {
-	//            print("❌ Error fetching activities: \(error)")
-	//            throw error
-	//        }
-	//    }
+
+	/// Updates an activity in both Firestore and the local ActivityManager
+	func updateActivity(activity: Activity, activityManager: ActivityManager) async {
+		do {
+			let activityData: [String: Any] = [
+				"steps": activity.steps,
+				"activeMinutes": activity.activeMinutes,
+				"activityType": activity.activityType,
+				"date": Timestamp(date: activity.date)
+			]
+			
+			let activityDocRef = try await activityDocument(activityId: activity.id ?? UUID().uuidString)
+			try await activityDocRef.setData(activityData, merge: true)
+
+			// Update in local ActivityManager
+            await activityManager.editActivity(activity)
+			
+			logger.debug("Activity updated successfully")
+		} catch {
+			logger.error("Could not update activity: \(error)")
+		}
+	}
+
+	/// Deletes an activity from both Firestore and the local ActivityManager
+	func deleteActivity(_ activity: Activity, activityManager: ActivityManager) async {
+		do {
+            let activityDocRef = try await activityDocument(activityId: activity.id ?? UUID().uuidString)
+			try await activityDocRef.delete()
+
+			await activityManager.deleteActivity(activity)
+			logger.debug("Activity deleted successfully")
+		} catch {
+			logger.error("Could not delete activity: \(error)")
+		}
+	}
 }

--- a/Stanford360/Activity/Model/Activity+StandardExtension.swift
+++ b/Stanford360/Activity/Model/Activity+StandardExtension.swift
@@ -47,6 +47,7 @@ extension Stanford360Standard {
 			try await activityDocRef.setData(activityData, merge: true)
 			
 			logger.debug("Activity stored successfully")
+            await ActivityScheduler().userLoggedActivity()
 		} catch {
 			logger.error("Could not store activity: \(error)")
 		}
@@ -69,8 +70,8 @@ extension Stanford360Standard {
 		return activities
 	}
 
-	/// Updates an activity in both Firestore and the local ActivityManager
-	func updateActivity(activity: Activity, activityManager: ActivityManager) async {
+	/// Updates an activity in both Firestore
+	func updateActivityFirestore(activity: Activity) async {
 		do {
 			let activityData: [String: Any] = [
 				"steps": activity.steps,
@@ -81,9 +82,6 @@ extension Stanford360Standard {
 			
 			let activityDocRef = try await activityDocument(activityId: activity.id ?? UUID().uuidString)
 			try await activityDocRef.setData(activityData, merge: true)
-
-			// Update in local ActivityManager
-            await activityManager.editActivity(activity)
 			
 			logger.debug("Activity updated successfully")
 		} catch {
@@ -91,13 +89,12 @@ extension Stanford360Standard {
 		}
 	}
 
-	/// Deletes an activity from both Firestore and the local ActivityManager
-	func deleteActivity(_ activity: Activity, activityManager: ActivityManager) async {
+	/// Deletes an activity from both Firestore
+	func deleteActivity(_ activity: Activity) async {
 		do {
             let activityDocRef = try await activityDocument(activityId: activity.id ?? UUID().uuidString)
 			try await activityDocRef.delete()
-
-			await activityManager.deleteActivity(activity)
+            
 			logger.debug("Activity deleted successfully")
 		} catch {
 			logger.error("Could not delete activity: \(error)")

--- a/Stanford360/Activity/Model/Activity.swift
+++ b/Stanford360/Activity/Model/Activity.swift
@@ -18,14 +18,12 @@ struct Activity: Identifiable, Codable, @unchecked Sendable {
     var date: Date
     var steps: Int
     var activeMinutes: Int
-    var caloriesBurned: Int
     var activityType: String
     
     init(
         date: Date,
         steps: Int,
         activeMinutes: Int,
-        caloriesBurned: Int,
         activityType: String,
         id: String? = UUID().uuidString
     ) {
@@ -33,7 +31,6 @@ struct Activity: Identifiable, Codable, @unchecked Sendable {
         self.date = date
         self.steps = steps
         self.activeMinutes = activeMinutes
-        self.caloriesBurned = caloriesBurned
         self.activityType = activityType
     }
 }

--- a/Stanford360/Activity/Model/ActivityManager.swift
+++ b/Stanford360/Activity/Model/ActivityManager.swift
@@ -46,17 +46,17 @@ class ActivityManager: Module, EnvironmentAccessible {
 		activities.reduce(0) { $0 + $1.activeMinutes }
 	}
 
-    // Method to edit an existing activity
-    func editActivity(_ updatedActivity: Activity) {
-        if let index = activities.firstIndex(where: { $0.id == updatedActivity.id }) {
-            activities[index] = updatedActivity
-        }
-    }
-
-    // Method to delete an activity
-    func deleteActivity(_ activity: Activity) {
-        activities.removeAll { $0.id == activity.id }
-    }
+//    // Method to edit an existing activity
+//    func editActivity(_ updatedActivity: Activity) {
+//        if let index = activities.firstIndex(where: { $0.id == updatedActivity.id }) {
+//            activities[index] = updatedActivity
+//        }
+//    }
+//
+//    // Method to delete an activity
+//    func deleteActivity(_ activity: Activity) {
+//        activities.removeAll { $0.id == activity.id }
+//    }
     
 //    func getTodayActivity() -> Activity? {
 //        let today = Calendar.current.startOfDay(for: Date())

--- a/Stanford360/Activity/Model/ActivityManager.swift
+++ b/Stanford360/Activity/Model/ActivityManager.swift
@@ -45,6 +45,18 @@ class ActivityManager: Module, EnvironmentAccessible {
 	func getTotalActivityMinutes(_ activities: [Activity]) -> Int {
 		activities.reduce(0) { $0 + $1.activeMinutes }
 	}
+
+    // Method to edit an existing activity
+    func editActivity(_ updatedActivity: Activity) {
+        if let index = activities.firstIndex(where: { $0.id == updatedActivity.id }) {
+            activities[index] = updatedActivity
+        }
+    }
+
+    // Method to delete an activity
+    func deleteActivity(_ activity: Activity) {
+        activities.removeAll { $0.id == activity.id }
+    }
     
 //    func getTodayActivity() -> Activity? {
 //        let today = Calendar.current.startOfDay(for: Date())
@@ -99,22 +111,6 @@ class ActivityManager: Module, EnvironmentAccessible {
         }
     }
     
-    // func sendActivityReminder() {
-    //     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["activityReminder"])
-        
-    //     let content = UNMutableNotificationContent()
-    //     content.title = "🏃 Keep Moving!"
-        
-    //     if getTodayTotalMinutes() >= 60 {
-    //         content.body = "🎉 Amazing! You've reached your daily goal of 60 minutes! Keep up the great work!"
-    //     } else {
-    //         let remainingMinutes = 60 - getTodayTotalMinutes()
-    //         content.body = "You're only \(remainingMinutes) minutes away from your daily goal! Keep going! 🚀"
-    //         let request = UNNotificationRequest(identifier: "activityReminder", content: content, trigger: nil)
-    //         UNUserNotificationCenter.current().add(request)
-    //     }
-    // }
-    
 //    private func loadFromStorage() {
 //        if let data = UserDefaults.standard.data(forKey: "activities"),
 //           let decoded = try? JSONDecoder().decode([Activity].self, from: data) {
@@ -127,30 +123,4 @@ class ActivityManager: Module, EnvironmentAccessible {
             UserDefaults.standard.set(data, forKey: "activities")
         }
     }
-    
-//    // Helper methods to get activities for different time frames
-//    func getActivitiesForTimeFrame(_ timeFrame: TimeFrame) -> [Activity] {
-//        let calendar = Calendar.current
-//        let now = Date()
-//        
-//        switch timeFrame {
-//        case .today:
-//            let todayActivities = activities.filter { calendar.isDateInToday($0.date) }
-//            return todayActivities
-//            
-//        case .week:
-//            guard let weekAgo = calendar.date(byAdding: .day, value: -7, to: now) else {
-//                return []
-//            }
-//            let weekActivities = activities.filter { $0.date >= weekAgo && $0.date <= now }
-//            return weekActivities
-//            
-//        case .month:
-//            guard let monthAgo = calendar.date(byAdding: .month, value: -1, to: now) else {
-//                return []
-//            }
-//            let monthActivities = activities.filter { $0.date >= monthAgo && $0.date <= now }
-//            return monthActivities
-//        }
-//    }
 }

--- a/Stanford360/Activity/Model/HealthKitActivity.swift
+++ b/Stanford360/Activity/Model/HealthKitActivity.swift
@@ -14,7 +14,6 @@ struct HealthKitActivity: Sendable {
     var date: Date
     var steps: Int
     var activeMinutes: Int
-    var caloriesBurned: Int
     var activityType: String
     
     func toActivity() -> Activity {
@@ -22,7 +21,6 @@ struct HealthKitActivity: Sendable {
             date: date,
             steps: steps,
             activeMinutes: activeMinutes,
-            caloriesBurned: caloriesBurned,
             activityType: activityType
         )
     }

--- a/Stanford360/Activity/View/ActivityBreakdownView.swift
+++ b/Stanford360/Activity/View/ActivityBreakdownView.swift
@@ -16,21 +16,21 @@ struct ActivityBreakdownView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 5) {
-               Text("Activity Breakdown")
-                   .font(.headline)
-                   .padding(.horizontal)
-               
-               ForEach(calculateBreakdown().sorted(by: { $0.value > $1.value }), id: \.key) { activity, minutes in
-                   HStack {
-                       Text(activity)
-                           .font(.subheadline)
-                       Spacer()
-                       Text("\(minutes) min")
-                           .font(.subheadline.bold())
-                           .foregroundStyle(.blue)
-                   }
-                   .padding(.horizontal)
-               }
+                Text("Activity Breakdown")
+                    .font(.headline)
+                    .padding(.horizontal)
+                
+                ForEach(calculateBreakdown().sorted(by: { $0.value > $1.value }), id: \.key) { activity, minutes in
+                    HStack {
+                        Text(activity)
+                            .font(.subheadline)
+                        Spacer()
+                        Text("\(minutes) min")
+                            .font(.subheadline.bold())
+                            .foregroundStyle(.blue)
+                    }
+                    .padding(.horizontal)
+                }
             }
             .padding()
             .background(
@@ -58,7 +58,6 @@ struct ActivityBreakdownView: View {
             date: Date(),
             steps: 8000,
             activeMinutes: 45,
-            caloriesBurned: 300,
             activityType: "Running"
         ),
         {
@@ -69,7 +68,6 @@ struct ActivityBreakdownView: View {
                 date: date,
                 steps: 6000,
                 activeMinutes: 30,
-                caloriesBurned: 200,
                 activityType: "Walking"
             )
         }(),
@@ -81,7 +79,6 @@ struct ActivityBreakdownView: View {
                 date: date,
                 steps: 7500,
                 activeMinutes: 40,
-                caloriesBurned: 250,
                 activityType: "Soccer"
             )
         }()

--- a/Stanford360/Activity/View/ActivityCardView.swift
+++ b/Stanford360/Activity/View/ActivityCardView.swift
@@ -49,7 +49,10 @@ struct ActivityCardView: View {
             Button(role: .destructive) {
                 isPerformingAction = true
                 Task {
-                    await standard.deleteActivity(activity, activityManager: activityManager)
+                    await standard.deleteActivity(activity)
+                    var updatedActivities = activityManager.activities
+                    updatedActivities.removeAll { $0.id == activity.id }
+                    activityManager.activities = updatedActivities
                     isPerformingAction = false
                 }
             } label: {

--- a/Stanford360/Activity/View/ActivityCardView.swift
+++ b/Stanford360/Activity/View/ActivityCardView.swift
@@ -12,7 +12,11 @@ import SwiftUI
 
 struct ActivityCardView: View {
     let activity: Activity
-    
+    @Environment(ActivityManager.self) private var activityManager
+    @Environment(Stanford360Standard.self) private var standard
+    @State private var showingAddActivitySheet = false
+    @State private var isPerformingAction = false
+
     var body: some View {
         HStack {
             // Activity Type with Emoji
@@ -32,6 +36,31 @@ struct ActivityCardView: View {
                 .fill(Color.white)
                 .shadow(radius: 2)
         )
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+            Button {
+                showingAddActivitySheet = true
+            } label: {
+                Label("Edit", systemImage: "pencil")
+            }
+            .tint(.blue)
+            .disabled(isPerformingAction)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive) {
+                isPerformingAction = true
+                Task {
+                    await standard.deleteActivity(activity, activityManager: activityManager)
+                    isPerformingAction = false
+                }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(isPerformingAction)
+        }
+        .sheet(isPresented: $showingAddActivitySheet) {
+            // Use the AddActivitySheet with the activity for editing
+            AddActivitySheet(activity: activity)
+        }
     }
 }
 
@@ -40,10 +69,12 @@ struct ActivityCardView: View {
         date: Date(),
         steps: 5000,
         activeMinutes: 45,
-        caloriesBurned: 200,
-        activityType: "Running"
+        activityType: "Running 🏃‍♂️",
+        id: "sample-id"
     )
     
     return ActivityCardView(activity: sampleActivity)
         .padding()
+        .environment(ActivityManager())
+        .environment(Stanford360Standard())
 }

--- a/Stanford360/Activity/View/ActivityChartView.swift
+++ b/Stanford360/Activity/View/ActivityChartView.swift
@@ -73,7 +73,6 @@ struct ActivityChartView: View {
             date: Date(),
             steps: 8000,
             activeMinutes: 45,
-            caloriesBurned: 300,
             activityType: "Running"
         ),
         {
@@ -84,7 +83,6 @@ struct ActivityChartView: View {
                 date: date,
                 steps: 6000,
                 activeMinutes: 30,
-                caloriesBurned: 200,
                 activityType: "Walking"
             )
         }()

--- a/Stanford360/Activity/View/ActivityTimeFrameView.swift
+++ b/Stanford360/Activity/View/ActivityTimeFrameView.swift
@@ -124,14 +124,12 @@ struct ActivityTimeFrameView: View {
             date: Date(),
             steps: 8000,
             activeMinutes: 45,
-            caloriesBurned: 300,
             activityType: "Running"
         ),
         Activity(
             date: Date(),
             steps: 5000,
             activeMinutes: 35,
-            caloriesBurned: 300,
             activityType: "Walking"
         )
     ]

--- a/Stanford360/Activity/View/ActivityView.swift
+++ b/Stanford360/Activity/View/ActivityView.swift
@@ -86,9 +86,28 @@ struct ActivityView: View {
         }
     }
     
-    init(presentingAccount: Binding<Bool>) {
-        self._presentingAccount = presentingAccount
+    // Extracted add activity button
+    private var addActivityButton: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                Button(action: { showingAddActivity = true }) {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 56))
+                        .foregroundColor(.blue)
+                        .shadow(radius: 3)
+                        .background(Circle().fill(.white))
+                        .accessibilityLabel("Add Activity Button")
+                }
+                .padding([.trailing, .bottom], 25)
+            }
+        }
     }
+	
+	init(presentingAccount: Binding<Bool>) {
+		self._presentingAccount = presentingAccount
+	}
 	
 	func loadActivities() async {
 		activityManager.activities = await standard.fetchActivities()

--- a/Stanford360/Activity/View/ActivityView.swift
+++ b/Stanford360/Activity/View/ActivityView.swift
@@ -85,25 +85,6 @@ struct ActivityView: View {
             showHealthKitAlert = true
         }
     }
-    
-    // Extracted add activity button
-    private var addActivityButton: some View {
-        VStack {
-            Spacer()
-            HStack {
-                Spacer()
-                Button(action: { showingAddActivity = true }) {
-                    Image(systemName: "plus.circle.fill")
-                        .font(.system(size: 56))
-                        .foregroundColor(.blue)
-                        .shadow(radius: 3)
-                        .background(Circle().fill(.white))
-                        .accessibilityLabel("Add Activity Button")
-                }
-                .padding([.trailing, .bottom], 25)
-            }
-        }
-    }
 	
 	init(presentingAccount: Binding<Bool>) {
 		self._presentingAccount = presentingAccount

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -45,10 +45,6 @@ struct DashboardView: View {
         self._presentingAccount = presentingAccount
     }
 	
-	init(presentingAccount: Binding<Bool>) {
-		self._presentingAccount = presentingAccount
-	}
-	
 	/// Loads the patient's activities, hydration, and meals into their respective managers and updates the patient's data accordingly
 	func loadPatientData() async {
 		let patientData = try? await standard.fetchPatientData()

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -31,10 +31,19 @@ struct DashboardView: View {
 					}
 				}
 		}
+		.toolbar {
+			if account != nil {
+				AccountButton(isPresented: $presentingAccount)
+			}
+		}
 		.task {
 			await loadPatientData()
 		}
 	}
+
+	init(presentingAccount: Binding<Bool>) {
+        self._presentingAccount = presentingAccount
+    }
 	
 	init(presentingAccount: Binding<Bool>) {
 		self._presentingAccount = presentingAccount

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -191,6 +191,15 @@
     "Day" : {
 
     },
+    "Delete" : {
+
+    },
+    "Edit" : {
+
+    },
+    "Edit Your Activity! 📝" : {
+
+    },
     "Enable HealthKit in Settings to auto-track steps, or log activities manually." : {
 
     },
@@ -511,6 +520,9 @@
     "Protein Progress" : {
 
     },
+    "Protein Tracker 🍗 " : {
+
+    },
     "Remaining" : {
 
     },
@@ -653,6 +665,9 @@
         }
       }
     },
+    "Update Activity! 🔄" : {
+
+    },
     "View" : {
 
     },
@@ -712,6 +727,9 @@
 
     },
     "Yearly Protein Intake" : {
+		
+	},
+    "You have some minutes left to reach your goal of 60 minutes!" : {
 
     },
     "You haven't logged any activity in the last 4 hours. Time to get moving!" : {

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -108,6 +108,9 @@
     "Activity Time" : {
 
     },
+    "Add Activity Button" : {
+
+    },
     "Add Your Activity! 🎯" : {
 
     },
@@ -520,9 +523,6 @@
     "Protein Progress" : {
 
     },
-    "Protein Tracker 🍗 " : {
-
-    },
     "Remaining" : {
 
     },
@@ -727,9 +727,6 @@
 
     },
     "Yearly Protein Intake" : {
-		
-	},
-    "You have some minutes left to reach your goal of 60 minutes!" : {
 
     },
     "You haven't logged any activity in the last 4 hours. Time to get moving!" : {

--- a/Stanford360/Shared/Data.swift
+++ b/Stanford360/Shared/Data.swift
@@ -16,28 +16,24 @@ let activitiesData = [
 		date: Calendar.current.date(byAdding: .day, value: -2, to: Date()) ?? Date(),
 		steps: 4000,
 		activeMinutes: 40,
-		caloriesBurned: 0,
 		activityType: "Walking"
 	),
 	Activity(
 		date: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date(),
 		steps: 2000,
 		activeMinutes: 20,
-		caloriesBurned: 0,
 		activityType: "Walking"
 	),
 	Activity(
 		date: Calendar.current.date(byAdding: .day, value: -1, to: Date()) ?? Date(),
 		steps: 1000,
 		activeMinutes: 10,
-		caloriesBurned: 0,
 		activityType: "Walking"
 	),
 	Activity(
 		date: Date.now,
 		steps: 5500,
 		activeMinutes: 55,
-		caloriesBurned: 0,
 		activityType: "Walking"
 	)
 ]

--- a/Stanford360/Stanford360Delegate.swift
+++ b/Stanford360/Stanford360Delegate.swift
@@ -104,20 +104,20 @@ class Stanford360Delegate: SpeziAppDelegate {
 		}
 	}
 	
-	private func requestNotificationPermission() {
-		let center = UNUserNotificationCenter.current()
-		center.getNotificationSettings { settings in
-			guard settings.authorizationStatus == .notDetermined else {
-				return
-			}
-
-			center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-				if granted {
-					print("Notification permission granted!")
-				} else if let error = error {
-					print("Failed to request notification permission: \(error)")
-				}
-			}
-		}
-	}
+//	private func requestNotificationPermission() {
+//		let center = UNUserNotificationCenter.current()
+//		center.getNotificationSettings { settings in
+//			guard settings.authorizationStatus == .notDetermined else {
+//				return
+//			}
+//
+//			center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+//				if granted {
+//					print("Notification permission granted!")
+//				} else if let error = error {
+//					print("Failed to request notification permission: \(error)")
+//				}
+//			}
+//		}
+//	}
 }

--- a/Stanford360/Stanford360Delegate.swift
+++ b/Stanford360/Stanford360Delegate.swift
@@ -23,9 +23,6 @@ import UserNotifications
 
 
 class Stanford360Delegate: SpeziAppDelegate {
-	//    let activityReminderTaskId = "com.stanford360.activityReminder"
-	//    let sharedActivityManager = ActivityManager()
-	
 	override var configuration: Configuration {
 		Configuration(standard: Stanford360Standard()) {
 			if !FeatureFlags.disableFirebase {
@@ -107,82 +104,20 @@ class Stanford360Delegate: SpeziAppDelegate {
 		}
 	}
 	
-	//    override func application(
-	//        _ application: UIApplication,
-	//        willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = [:]
-	//    ) -> Bool {
-	//        registerBackgroundTask()
-	//        scheduleBackgroundActivityReminder()
-	//        if !UserDefaults.standard.bool(forKey: "hasAskedForNotificationPermission") {
-	//            requestNotificationPermission()
-	//        }
-	//        return true
-	//    }
-	//
-	//    /// Registers the background task
-	//    private func registerBackgroundTask() {
-	//        BGTaskScheduler.shared.register(
-	//            forTaskWithIdentifier: activityReminderTaskId,
-	//            using: nil
-	//        ) { task in
-	//            if let task = task as? BGAppRefreshTask {
-	//                self.handleBackgroundActivityReminder(
-	//                    task: task,
-	//                    activityManager: self.sharedActivityManager
-	//                )
-	//            }
-	//        }
-	//    }
-	//
-	//    /// Schedules the background task to start at 8 AM and repeat every 5 hours
-	//    func scheduleBackgroundActivityReminder() {
-	//        let request = BGAppRefreshTaskRequest(identifier: activityReminderTaskId)
-	//
-	//        guard let baseDate = Calendar.current.date(
-	//            bySettingHour: 8,
-	//            minute: 0,
-	//            second: 0,
-	//            of: Date()
-	//        ) else {
-	//            print("Failed to compute base date for scheduling.")
-	//            return
-	//        }
-	//        let nextRun = baseDate.addingTimeInterval(5 * 60 * 60) // 8 AM first, then run every 5 hours
-	//        request.earliestBeginDate = nextRun
-	//
-	//        do {
-	//            try BGTaskScheduler.shared.submit(request)
-	//            if let earliestDate = request.earliestBeginDate {
-	//                print("Scheduled background activity reminder at \(earliestDate)")
-	//            } else {
-	//                print("Failed to retrieve earliest begin date.")
-	//            }
-	//        } catch {
-	//            print("Failed to schedule activity reminder: \(error.localizedDescription)")
-	//        }
-	//    }
-	//
-	//    /// Handles the background task execution
-	//    func handleBackgroundActivityReminder(task: BGAppRefreshTask, activityManager: ActivityManager) {
-	//        activityManager.sendActivityReminder()
-	//        task.setTaskCompleted(success: true)
-	//        scheduleBackgroundActivityReminder() // Reschedule for continuous monitoring
-	//    }
-	
-//	private func requestNotificationPermission() {
-//		let center = UNUserNotificationCenter.current()
-//		center.getNotificationSettings { settings in
-//			guard settings.authorizationStatus == .notDetermined else {
-//				return
-//			}
-//
-//			center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
-//				if granted {
-//					print("Notification permission granted!")
-//				} else if let error = error {
-//					print("Failed to request notification permission: \(error)")
-//				}
-//			}
-//		}
-//	}
+	private func requestNotificationPermission() {
+		let center = UNUserNotificationCenter.current()
+		center.getNotificationSettings { settings in
+			guard settings.authorizationStatus == .notDetermined else {
+				return
+			}
+
+			center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+				if granted {
+					print("Notification permission granted!")
+				} else if let error = error {
+					print("Failed to request notification permission: \(error)")
+				}
+			}
+		}
+	}
 }

--- a/Stanford360Tests/ActivityTests/ActivityManagerTest.swift
+++ b/Stanford360Tests/ActivityTests/ActivityManagerTest.swift
@@ -50,7 +50,6 @@ final class ActivityManagerTests: XCTestCase {
 //            date: Date(),
 //            steps: 5000,
 //            activeMinutes: 50,
-//            caloriesBurned: 200,
 //            activityType: "Running"
 //        )
 //
@@ -79,21 +78,18 @@ final class ActivityManagerTests: XCTestCase {
 //                    date: today,
 //                    steps: 6000,
 //                    activeMinutes: 60,
-//                    caloriesBurned: 250,
 //                    activityType: "Running"
 //                ),
 //                Activity(
 //                    date: yesterday,
 //                    steps: 7000,
 //                    activeMinutes: 70,
-//                    caloriesBurned: 280,
 //                    activityType: "Cycling"
 //                ),
 //                Activity(
 //                    date: twoDaysAgo,
 //                    steps: 9000,
 //                    activeMinutes: 90,
-//                    caloriesBurned: 220,
 //                    activityType: "Walking"
 //                )
 //            ]
@@ -116,9 +112,9 @@ final class ActivityManagerTests: XCTestCase {
 //           if let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: today),
 //              let fiveDaysAgo = Calendar.current.date(byAdding: .day, value: -5, to: today) {
 //               let activities = [
-//                   Activity(date: today, steps: 8000, activeMinutes: 80, caloriesBurned: 300, activityType: "Running"),
-//                   Activity(date: threeDaysAgo, steps: 7000, activeMinutes: 70, caloriesBurned: 280, activityType: "Cycling"),
-//                   Activity(date: fiveDaysAgo, steps: 10000, activeMinutes: 100, caloriesBurned: 350, activityType: "Swimming")
+//                   Activity(date: today, steps: 8000, activeMinutes: 80, activityType: "Running"),
+//                   Activity(date: threeDaysAgo, steps: 7000, activeMinutes: 70,  activityType: "Cycling"),
+//                   Activity(date: fiveDaysAgo, steps: 10000, activeMinutes: 100, activityType: "Swimming")
 //               ]
 //               
 //               manager.activities = activities
@@ -141,10 +137,10 @@ final class ActivityManagerTests: XCTestCase {
 //              let eightDaysAgo = Calendar.current.date(byAdding: .day, value: -8, to: today) {  // This should be excluded
 //               
 //               let activities = [
-//                   Activity(date: today, steps: 6000, activeMinutes: 60, caloriesBurned: 250, activityType: "Running"),
-//                   Activity(date: oneDayAgo, steps: 5000, activeMinutes: 50, caloriesBurned: 200, activityType: "Jogging"),
-//                   Activity(date: threeDaysAgo, steps: 4000, activeMinutes: 40, caloriesBurned: 150, activityType: "Walking"),
-//                   Activity(date: eightDaysAgo, steps: 3000, activeMinutes: 30, caloriesBurned: 100, activityType: "Yoga") // Should NOT be included
+//                   Activity(date: today, steps: 6000, activeMinutes: 60, activityType: "Running"),
+//                   Activity(date: oneDayAgo, steps: 5000, activeMinutes: 50, activityType: "Jogging"),
+//                   Activity(date: threeDaysAgo, steps: 4000, activeMinutes: 40, activityType: "Walking"),
+//                   Activity(date: eightDaysAgo, steps: 3000, activeMinutes: 30, activityType: "Yoga") // Should NOT be included
 //               ]
 //               
 //               manager.activities = activities
@@ -165,7 +161,6 @@ final class ActivityManagerTests: XCTestCase {
 //            date: today,
 //            steps: 4000,
 //            activeMinutes: 40,
-//            caloriesBurned: 180,
 //            activityType: "Jogging"
 //        )
 //
@@ -186,7 +181,6 @@ final class ActivityManagerTests: XCTestCase {
 ////            date: Date(),
 ////            steps: 5000,
 ////            activeMinutes: 50,
-////            caloriesBurned: 200,
 ////            activityType: "Running"
 ////        )
 ////        manager.logActivityToView(activity)
@@ -210,7 +204,6 @@ final class ActivityManagerTests: XCTestCase {
 //                    date: date,
 //                    steps: 3000,
 //                    activeMinutes: 30,
-//                    caloriesBurned: 300,
 //                    activityType: "Running"
 //                )
 //            }(),
@@ -222,7 +215,6 @@ final class ActivityManagerTests: XCTestCase {
 //                    date: date,
 //                    steps: 2000,
 //                    activeMinutes: 20,
-//                    caloriesBurned: 200,
 //                    activityType: "Walking"
 //                )
 //            }()
@@ -266,7 +258,6 @@ final class ActivityManagerTests: XCTestCase {
 //                date: Date(),
 //                steps: 6000,
 //                activeMinutes: 60,
-//                caloriesBurned: 250,
 //                activityType: "Running"
 //            )
 //

--- a/Stanford360Tests/ActivityTests/DraftActivityManagerTest.swift
+++ b/Stanford360Tests/ActivityTests/DraftActivityManagerTest.swift
@@ -69,21 +69,18 @@
 //                    date: today,
 //                    steps: 6000,
 //                    activeMinutes: 60,
-//                    caloriesBurned: 250,
 //                    activityType: "Running"
 //                ),
 //                Activity(
 //                    date: yesterday,
 //                    steps: 7000,
 //                    activeMinutes: 70,
-//                    caloriesBurned: 280,
 //                    activityType: "Cycling"
 //                ),
 //                Activity(
 //                    date: twoDaysAgo,
 //                    steps: 9000,
 //                    activeMinutes: 90,
-//                    caloriesBurned: 220,
 //                    activityType: "Walking"
 //                )
 //            ]
@@ -106,9 +103,9 @@
 //           if let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: today),
 //              let fiveDaysAgo = Calendar.current.date(byAdding: .day, value: -5, to: today) {
 //               let activities = [
-//                   Activity(date: today, steps: 8000, activeMinutes: 80, caloriesBurned: 300, activityType: "Running"),
-//                   Activity(date: threeDaysAgo, steps: 7000, activeMinutes: 70, caloriesBurned: 280, activityType: "Cycling"),
-//                   Activity(date: fiveDaysAgo, steps: 10000, activeMinutes: 100, caloriesBurned: 350, activityType: "Swimming")
+//                   Activity(date: today, steps: 8000, activeMinutes: 80, activityType: "Running"),
+//                   Activity(date: threeDaysAgo, steps: 7000, activeMinutes: 70, activityType: "Cycling"),
+//                   Activity(date: fiveDaysAgo, steps: 10000, activeMinutes: 100,  activityType: "Swimming")
 //               ]
 //               
 //               manager.activities = activities

--- a/Stanford360Tests/ActivityTests/HealthKitActivityTests.swift
+++ b/Stanford360Tests/ActivityTests/HealthKitActivityTests.swift
@@ -19,7 +19,6 @@ final class HealthKitActivityTests: XCTestCase {
             date: date,
             steps: 1000,
             activeMinutes: 30,
-            caloriesBurned: 100,
             activityType: "HealthKit"
         )
         
@@ -30,7 +29,6 @@ final class HealthKitActivityTests: XCTestCase {
         XCTAssertEqual(activity.date, date)
         XCTAssertEqual(activity.steps, 1000)
         XCTAssertEqual(activity.activeMinutes, 30)
-        XCTAssertEqual(activity.caloriesBurned, 100)
         XCTAssertEqual(activity.activityType, "HealthKit")
     }
 }

--- a/Stanford360Tests/ActivityTests/HealthKitManagerTests.swift
+++ b/Stanford360Tests/ActivityTests/HealthKitManagerTests.swift
@@ -27,20 +27,18 @@
 //    }
 //
 //    func testReadDailyActivity() async throws {
-//        let expectedActivity = HealthKitActivity(date: Date(), steps: 5000, activeMinutes: 30, caloriesBurned: 200, activityType: "HealthKit")
+//        let expectedActivity = HealthKitActivity(date: Date(), steps: 5000, activeMinutes: 30, activityType: "HealthKit")
 //        mockHealthStore.stepCount = 5000
 //        mockHealthStore.activeMinutes = 30
-//        mockHealthStore.caloriesBurned = 200
 //
 //        let activity = try await healthKitManager.readDailyActivity(for: Date())
 //
 //        XCTAssertEqual(activity.steps, expectedActivity.steps)
 //        XCTAssertEqual(activity.activeMinutes, expectedActivity.activeMinutes)
-//        XCTAssertEqual(activity.caloriesBurned, expectedActivity.caloriesBurned)
 //    }
 //
 //    func testSaveActivity() async throws {
-//        let activity = Activity(date: Date(), steps: 8000, activeMinutes: 60, caloriesBurned: 400, activityType: "Manual")
+//        let activity = Activity(date: Date(), steps: 8000, activeMinutes: 60, activityType: "Manual")
 //
 //        try await healthKitManager.saveActivity(activity)
 //
@@ -53,7 +51,6 @@
 //    var saveCalled = false
 //    var stepCount = 0
 //    var activeMinutes = 0
-//    var caloriesBurned = 0
 //
 //    override func requestAuthorization(toShare typesToShare: Set<HKSampleType>?, read typesToRead: Set<HKObjectType>?, completion: @escaping (Bool, Error?) -> Void) {
 //        requestAuthorizationCalled = true
@@ -81,8 +78,6 @@
 //            return Double(stepCount)
 //        case HKObjectType.quantityType(forIdentifier: .appleExerciseTime)!:
 //            return Double(activeMinutes)
-//        case HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!:
-//            return Double(caloriesBurned)
 //        default:
 //            return 0
 //        }


### PR DESCRIPTION
# :recycle: Removed Calories Attribute, Added Edit/Delete Activity Function, and Notifications  

## :recycle: Current Situation & Problem  
This PR addresses the following changes:  
- **Removed the `calories` attribute from the `Activity` model** as it was deemed unnecessary.  
- **Added `edit` and `delete` activity functions** to allow users to modify or remove activities dynamically.  
- **Implemented notifications every 5 hours from 9 AM to 9 PM** if the remaining activity minutes are greater than 0, ensuring users stay on track with their activities.  

## :gear: Release Notes  
- **Breaking Change:** The `calories` attribute has been removed from the `Activity` model. If this attribute was being used elsewhere, make necessary adjustments.  
- **New Features:**  
  - Added `edit_activity()` and `delete_activity()` functions to manage user activities.  
  - Introduced periodic notifications (at 9 AM, 2 PM, 7 PM) if the user has remaining activity minutes.  
<img width="391" alt="Capture d’écran 2025-03-03 à 11 40 07" src="https://github.com/user-attachments/assets/42523878-6089-46e1-9a47-8c831f65acd2" />

## :books: Documentation  
These changes have been documented according to the [[Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md)](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).  
- The `Activity` model no longer includes the `calories` field.  
- New functions (`edit_activity` and `delete_activity`) allow for better activity management.  
- Notification logic has been added to remind users about pending activity minutes.  

## :white_check_mark: Testing  
Not being tested yet.

## :pencil: [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) & Contributing Guidelines  
By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [[Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md)](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):  
- [x] I agree to follow the [[Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md)](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [[Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md)](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).  