### PR TITLE
improve weight notifications

### DIFF
--- a/Stanford360.xcodeproj/project.pbxproj
+++ b/Stanford360.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		A9DFE8A92ABE551400428242 /* AccountButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9DFE8A82ABE551400428242 /* AccountButton.swift */; };
 		A9FE7AD02AA39BAB0077B045 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */; };
 		C13ED86B2D656A0400033A55 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13ED8692D656A0400033A55 /* FeedView.swift */; };
+		C14F7E202D7704AE00916AAE /* AppNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14F7E1F2D7704AE00916AAE /* AppNavigationState.swift */; };
 		C156248A2D6D6D9300298CEB /* DayTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15624892D6D6D9300298CEB /* DayTimelineView.swift */; };
 		C15624902D6D6E6E00298CEB /* InfiniteDayTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C156248F2D6D6E6E00298CEB /* InfiniteDayTimelineView.swift */; };
 		C15C64082D75CF8500979C62 /* LogWeightSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15C64072D75CF8500979C62 /* LogWeightSheet.swift */; };
@@ -148,6 +149,7 @@
 		A9DFE8A82ABE551400428242 /* AccountButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountButton.swift; sourceTree = "<group>"; };
 		A9FE7ACF2AA39BAB0077B045 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
 		C13ED8692D656A0400033A55 /* FeedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
+		C14F7E1F2D7704AE00916AAE /* AppNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationState.swift; sourceTree = "<group>"; };
 		C15624892D6D6D9300298CEB /* DayTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTimelineView.swift; sourceTree = "<group>"; };
 		C156248F2D6D6E6E00298CEB /* InfiniteDayTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteDayTimelineView.swift; sourceTree = "<group>"; };
 		C15C64072D75CF8500979C62 /* LogWeightSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogWeightSheet.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				2FE5DC3B29EDD7D0004B9AB4 /* Schedule */,
 				2FE5DC3C29EDD7DA004B9AB4 /* SharedContext */,
 				2FC9759D2978E30800BA99FE /* Supporting Files */,
+				C14F7E1F2D7704AE00916AAE /* AppNavigationState.swift */,
 			);
 			path = Stanford360;
 			sourceTree = "<group>";
@@ -629,6 +632,7 @@
 				653A2551283387FE005D4D48 /* Stanford360.swift in Sources */,
 				2FE5DC3629EDD7CA004B9AB4 /* HealthKitPermissions.swift in Sources */,
 				C15C640A2D75CFF700979C62 /* LogWeightView.swift in Sources */,
+				C14F7E202D7704AE00916AAE /* AppNavigationState.swift in Sources */,
 				2F65B44E2A3B8B0600A36932 /* NotificationPermissions.swift in Sources */,
 				2FE5DC2629EDD38A004B9AB4 /* Contacts.swift in Sources */,
 			);

--- a/Stanford360/Account/AccountSheet.swift
+++ b/Stanford360/Account/AccountSheet.swift
@@ -33,7 +33,9 @@ struct AccountSheet: View {
                             Text("License Information")
                         }
 						
-						LogWeightView()
+						Section(header: Text("Weekly Check-In")) {
+							LogWeightView()
+						}
                     }
                 } else {
                     AccountSetup { _ in

--- a/Stanford360/Account/LogWeightSheet.swift
+++ b/Stanford360/Account/LogWeightSheet.swift
@@ -9,10 +9,12 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
 import SwiftUI
 
 struct LogWeightSheet: View {
 	@Environment(PatientManager.self) var patientManager
+	@Environment(PatientScheduler.self) var patientScheduler
 	
 	@Binding var weight: String
 	@Binding var showSheet: Bool
@@ -27,7 +29,10 @@ struct LogWeightSheet: View {
 				
 				Button("Save") {
 					if let weightValue = Double(weight) {
-						patientManager.updateWeight(Double(weight) ?? 0)
+						patientScheduler.maybeClearNotifications(loggedWeightTimestamp: .now)
+						patientManager.updateWeight(weightValue)
+					} else {
+						print("Please enter a valid weight value.")
 					}
 					weight = ""
 					showSheet = false

--- a/Stanford360/AppNavigationState.swift
+++ b/Stanford360/AppNavigationState.swift
@@ -1,0 +1,19 @@
+//
+//  AppNavigationState.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 3/4/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SwiftUI
+
+@MainActor
+@Observable
+final class AppNavigationState: Module, EnvironmentAccessible {
+	var showAccountSheet: Bool = false
+}

--- a/Stanford360/Dashboard/Models/Patient.swift
+++ b/Stanford360/Dashboard/Models/Patient.swift
@@ -12,6 +12,7 @@
 import Foundation
 
 struct Patient {
+	// periphery:ignore - weight will be stored to firestore in a follow up pr
 	var weight: Measurement<UnitMass>
 	var activityMinutes: Int
 	var hydrationOunces: Double

--- a/Stanford360/Dashboard/Service/PatientManager.swift
+++ b/Stanford360/Dashboard/Service/PatientManager.swift
@@ -16,12 +16,14 @@ import Spezi
 class PatientManager: Module, EnvironmentAccessible {
 	var patient: Patient
 	
-	init(patient: Patient = Patient(
-		weight: Measurement(value: 0, unit: .pounds),
-		activityMinutes: 0,
-		hydrationOunces: 0,
-		proteinGrams: 0
-	)) {
+	init(
+		patient: Patient = Patient(
+			weight: Measurement(value: 0, unit: .pounds),
+			activityMinutes: 0,
+			hydrationOunces: 0,
+			proteinGrams: 0
+		)
+	) {
 		self.patient = patient
 	}
 	

--- a/Stanford360/Dashboard/Service/PatientScheduler.swift
+++ b/Stanford360/Dashboard/Service/PatientScheduler.swift
@@ -16,8 +16,9 @@ import SpeziViews
 import UserNotifications
 
 @Observable
-final class PatientScheduler: Module, DefaultInitializable, EnvironmentAccessible {
+final class PatientScheduler: Module, DefaultInitializable, EnvironmentAccessible, NotificationHandler {
 	@Dependency(Scheduler.self) @ObservationIgnored private var scheduler
+	@Dependency(AppNavigationState.self) @ObservationIgnored private var navigationState
 	
 	@MainActor var viewState: ViewState = .idle
 	
@@ -55,6 +56,32 @@ final class PatientScheduler: Module, DefaultInitializable, EnvironmentAccessibl
 			viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create or update scheduled tasks."))
 		}
 	}
+	
+	func handleNotificationAction(_ response: UNNotificationResponse) {
+		print("✅ handleNotificationAction called with response: \(response)")
+		
+		let userInfo = response.notification.request.content.userInfo
+		print("🔍 userInfo: \(userInfo)")
+		
+		if let taskId = userInfo["edu.stanford.spezi.scheduler.notification.taskId"] as? String {
+			print("✅ Extracted taskId: \(taskId)")
+			navigateToView(for: taskId)
+		} else {
+			print("❌ Failed to extract taskId")
+		}
+	}
+	
+	@MainActor
+	private func navigateToView(for taskId: String) {
+		switch taskId {
+		case saturdayWeightNotificationTaskID, sundayWeightNotificationTaskID:
+			print("✅ Setting showAccountSheet to true")
+			navigationState.showAccountSheet = true
+		default:
+			break
+		}
+	}
+	
 	
 	/// Handles notifications after a user has logged their weight
 	///

--- a/Stanford360/Dashboard/Service/PatientScheduler.swift
+++ b/Stanford360/Dashboard/Service/PatientScheduler.swift
@@ -21,27 +21,63 @@ final class PatientScheduler: Module, DefaultInitializable, EnvironmentAccessibl
 	
 	@MainActor var viewState: ViewState = .idle
 	
-	private let weeklyWeightNotificationTaskID = "weekly-weight-notification"
+	private let saturdayWeightNotificationTaskID = "saturday-weight-notification"
+	private let sundayWeightNotificationTaskID = "sunday-weight-notification"
 	
 	init() {}
 	
 	func configure() {
-		scheduleWeeklyWeightNotification()
+		// this notification will be cancelled if the user logs their weight on Saturday before 9 AM
+		scheduleWeeklyWeightNotifications(
+			taskId: saturdayWeightNotificationTaskID,
+			weekday: .saturday
+		)
+		
+		// this notification will be cancelled if the user logs their weight on Saturday or before Sunday 9 AM
+		scheduleWeeklyWeightNotifications(
+			taskId: saturdayWeightNotificationTaskID,
+			weekday: .sunday
+		)
 	}
 	
-	/// Schedules a notification weekly on Mondays at 9 AM, reminding the user to fill out their "updates" (weight)
+	/// Schedules notifications weekly on Saturday and Sundays at 9 AM, reminding the user to fill out their "updates" (weight)
 	@MainActor
-	private func scheduleWeeklyWeightNotification() {
+	private func scheduleWeeklyWeightNotifications(taskId: String, weekday: Locale.Weekday) {
 		do {
 			try scheduler.createOrUpdateTask(
-				id: weeklyWeightNotificationTaskID,
+				id: taskId,
 				title: "📝 Weekly Check-In",
 				instructions: "Let's keep track of your journey! It's time to fill out your updates.",
-				schedule: .weekly(weekday: .saturday, hour: 9, minute: 0, startingAt: .today),
+				schedule: .weekly(weekday: weekday, hour: 9, minute: 0, startingAt: .today),
 				scheduleNotifications: true
 			)
 		} catch {
 			viewState = .error(AnyLocalizedError(error: error, defaultErrorDescription: "Failed to create or update scheduled tasks."))
+		}
+	}
+	
+	/// Handles notifications after a user has logged their weight
+	///
+	/// If the user logs their weight on Saturday before the 9 AM notification, this function will
+	/// clears both notifications
+	/// If the user logs their weight in between the Saturday and Sunday 9 AM notification, this
+	/// function will clear the Sunday notification
+	@MainActor
+	func maybeClearNotifications(loggedWeightTimestamp: Date) {
+		let weekday = Calendar.current.component(.weekday, from: loggedWeightTimestamp)
+		
+		// if the user logged weight saturday or sunday, clear notifications
+		if weekday == 7 || weekday == 1 {
+			do {
+				let scheduledTasksToClear = try scheduler.queryTasks(
+					for: Date()..<Date().addingTimeInterval(60 * 60 * 24 * 2), // at most, need the next 2 days
+					predicate: #Predicate { $0.id == saturdayWeightNotificationTaskID || $0.id == sundayWeightNotificationTaskID }
+				)
+				
+				try scheduler.deleteTasks(scheduledTasksToClear)
+			} catch {
+				print("There was an error querying or deleting tasks: \(error)")
+			}
 		}
 	}
 }

--- a/Stanford360/Dashboard/Views/DashboardView.swift
+++ b/Stanford360/Dashboard/Views/DashboardView.swift
@@ -37,7 +37,6 @@ struct DashboardView: View {
 			}
 		}
 		.task {
-			print(patientManager.patient.weight)
 			await loadPatientData()
 		}
 	}

--- a/Stanford360/HomeView.swift
+++ b/Stanford360/HomeView.swift
@@ -23,6 +23,8 @@ struct HomeView: View {
 	@AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.home
 	@AppStorage(StorageKeys.tabViewCustomization) private var tabViewCustomization = TabViewCustomization()
 	
+	@Environment(AppNavigationState.self) private var navigationState
+	
 	@State private var presentingAccount = false
 	
 	var body: some View {
@@ -56,6 +58,19 @@ struct HomeView: View {
 		.tabViewCustomization($tabViewCustomization)
 		.sheet(isPresented: $presentingAccount) {
 			AccountSheet(dismissAfterSignIn: false) // presentation was user initiated, do not automatically dismiss
+		}
+		.sheet(isPresented: Binding(
+			get: { navigationState.showAccountSheet },
+			set: { newValue in
+				if !newValue {
+					navigationState.showAccountSheet = false
+				}
+			}
+		)) {
+			AccountSheet()
+		}
+		.onAppear {
+			print("✅ HomeView loaded, showAccountSheet: \(navigationState.showAccountSheet)")
 		}
 		.accountRequired(!FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding) {
 			AccountSheet()

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -721,9 +721,6 @@
     "Today" : {
 
     },
-    "Today's Activities" : {
-
-    },
     "Unsupported Event" : {
       "localizations" : {
         "en" : {

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -131,7 +131,7 @@
       }
     },
     "Analyzing meals..." : {
-    
+
     },
     "Balanced Plate Recommendations" : {
 
@@ -227,10 +227,10 @@
     "flame" : {
 
     },
-    "fork" : {
-    
-    },
     "Food in common restaurants recommendations" : {
+
+    },
+    "fork" : {
 
     },
     "fork_background" : {
@@ -563,7 +563,7 @@
 
     },
     "plus.circle" : {
-    
+
     },
     "Produce In Season Recommendations" : {
 
@@ -738,6 +738,9 @@
 
     },
     "Week" : {
+
+    },
+    "Weekly Check-In" : {
 
     },
     "Weekly Hydration" : {

--- a/Stanford360/Stanford360.swift
+++ b/Stanford360/Stanford360.swift
@@ -16,7 +16,7 @@ import SwiftUI
 struct Stanford360: App {
     @UIApplicationDelegateAdaptor(Stanford360Delegate.self) var appDelegate
     @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
-    
+	    
     var body: some Scene {
         WindowGroup {
             ZStack {

--- a/Stanford360/Stanford360Delegate.swift
+++ b/Stanford360/Stanford360Delegate.swift
@@ -53,6 +53,7 @@ class Stanford360Delegate: SpeziAppDelegate {
 			
 			OnboardingDataSource()
 			Notifications()
+			AppNavigationState()
 			
 			// Schedulers
 			Stanford360Scheduler()


### PR DESCRIPTION
# *improve weight notifications*

## :recycle: Current situation & Problem
Currently, notifications to remind the user to log their weight are always sent Saturdays and Sundays, even if the user logged their weight already for the week.


## :gear: Release Notes 
* Cancels weight notifications for the weekend if the user logs their weight, only sending notifications again the following Saturday and Sunday
* Clicking the weight notification opens the app and navigates the user to the `AccountSheet` view, which is where they log their weight

https://github.com/user-attachments/assets/224d20b0-3291-4646-8756-2eea44f49212


## :books: Documentation
N/A


## :white_check_mark: Testing
Testing was done locally. Written tests are on pause until we understand what is causing them to pass locally but break in the CI.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
