### PR TITLE
scrap feed view

### DIFF
--- a/Stanford360/Feed/DailyScheduleView.swift
+++ b/Stanford360/Feed/DailyScheduleView.swift
@@ -265,7 +265,7 @@ struct DailyScheduleView: View {
 }
 
 #Preview {
-	@Previewable @State var selectedTab = HomeView.Tabs.home
+	@Previewable @State var selectedTab = HomeView.Tabs.dashboard
 	@Previewable @State var date = Date.now
 	@Previewable @State var taskStore = TaskStore()
 	

--- a/Stanford360/Feed/DayTimelineView.swift
+++ b/Stanford360/Feed/DayTimelineView.swift
@@ -137,7 +137,7 @@ struct DayTimelineView: View {
 }
 
 #Preview {
-	@Previewable @State var selectedTab = HomeView.Tabs.home
+	@Previewable @State var selectedTab = HomeView.Tabs.dashboard
 	
 	DayTimelineView(selectedTab: $selectedTab)
 }

--- a/Stanford360/Feed/FeedView.swift
+++ b/Stanford360/Feed/FeedView.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 struct FeedView: View {
 	@Environment(Account.self) private var account: Account?
-	@AppStorage(StorageKeys.homeTabSelection) private var selectedTab = HomeView.Tabs.home
+	@AppStorage(StorageKeys.homeTabSelection) private var selectedTab = HomeView.Tabs.dashboard
 	
 	@Binding private var presentingAccount: Bool
 	

--- a/Stanford360/HomeView.swift
+++ b/Stanford360/HomeView.swift
@@ -13,14 +13,13 @@ import SwiftUI
 
 struct HomeView: View {
 	enum Tabs: String {
-		case home
+		case dashboard
 		case hydration
 		case protein
 		case activity
-		case dashboard
 	}
 	
-	@AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.home
+	@AppStorage(StorageKeys.homeTabSelection) private var selectedTab = Tabs.dashboard
 	@AppStorage(StorageKeys.tabViewCustomization) private var tabViewCustomization = TabViewCustomization()
 	
 	@Environment(AppNavigationState.self) private var navigationState
@@ -29,10 +28,10 @@ struct HomeView: View {
 	
 	var body: some View {
 		TabView(selection: $selectedTab) {
-			Tab("Home", systemImage: "house.fill", value: .home) {
-				FeedView(presentingAccount: $presentingAccount)
+			Tab("Dashboard", systemImage: "target", value: .dashboard) {
+				DashboardView(presentingAccount: $presentingAccount)
 			}
-			.customizationID("home.home")
+			.customizationID("home.dashboard")
 			
 			Tab("Activity", systemImage: "figure.walk", value: .activity) {
 				ActivityView(presentingAccount: $presentingAccount)
@@ -40,8 +39,7 @@ struct HomeView: View {
 			.customizationID("home.activity")
 			
 			Tab("Hydration", systemImage: "drop.fill", value: .hydration) {
-                HydrationTrackerView(presentingAccount: $presentingAccount)
-                // HydrationTrackerView()
+				HydrationTrackerView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.hydration")
 			
@@ -49,11 +47,6 @@ struct HomeView: View {
 				ProteinView(presentingAccount: $presentingAccount)
 			}
 			.customizationID("home.protein")
-			
-			Tab("Dashboard", systemImage: "target", value: .dashboard) {
-				DashboardView(presentingAccount: $presentingAccount)
-			}
-			.customizationID("home.dashboard")
 		}
 		.tabViewStyle(.sidebarAdaptable)
 		.tabViewCustomization($tabViewCustomization)
@@ -69,9 +62,6 @@ struct HomeView: View {
 			}
 		)) {
 			AccountSheet()
-		}
-		.onAppear {
-			print("✅ HomeView loaded, showAccountSheet: \(navigationState.showAccountSheet)")
 		}
 		.accountRequired(!FeatureFlags.disableFirebase && !FeatureFlags.skipOnboarding) {
 			AccountSheet()

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -314,9 +314,6 @@
         }
       }
     },
-    "Home" : {
-
-    },
     "How many minutes?" : {
 
     },


### PR DESCRIPTION
# *scrap feed view*

## :recycle: Current situation & Problem
Currently, the `FeedView` remains in preliminary stages. This is also not a key feature asked for in the app, so spending time on it when other key features need to be completed is not productive.


## :gear: Release Notes 
* Scraps the feed view from the app, rearranging the tabs as follows: Dashboard, Activity, Hydration, Protein
  <img width="371" alt="Screenshot 2025-03-04 at 12 51 58 PM" src="https://github.com/user-attachments/assets/f14cba66-b16a-4b8c-bbca-a3853fafe8a4" />


## :books: Documentation
All code related to the `FeedView` remains in the codebase in hopes of revisiting it in the future.


## :white_check_mark: Testing
Testing was done locally. Written tests are on pause until we understand what is causing them to pass locally but break in the CI.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
