### PR TITLE
milestone feature refactor and added to protein view

### DIFF
--- a/Stanford360/Hydration/Model/HydrationManager.swift
+++ b/Stanford360/Hydration/Model/HydrationManager.swift
@@ -12,6 +12,7 @@ import Spezi
 @Observable
 class HydrationManager: Module, EnvironmentAccessible {
     var hydration: [HydrationLog] = []
+    let milestoneManager = MilestoneManager()
 
     var hydrationByDate: [Date: [HydrationLog]] {
         var logsByDate: [Date: [HydrationLog]] = [:]
@@ -60,9 +61,16 @@ class HydrationManager: Module, EnvironmentAccessible {
         logs.reduce(0) { $0 + $1.hydrationOunces }
     }
     
+    /*
     func getLatestMilestone() -> Double {
         let totalIntake = getTodayTotalOunces()
         return Double((Int(totalIntake) / 20) * 20)
+    }
+     */
+    
+    func getLatestMilestone() -> Double {
+        let totalIntake = getTodayTotalOunces()
+        return milestoneManager.getLatestMilestone(total: totalIntake)
     }
     
     func calculateStreak() -> Int {

--- a/Stanford360/Hydration/View/HydrationControlPanel.swift
+++ b/Stanford360/Hydration/View/HydrationControlPanel.swift
@@ -39,7 +39,6 @@ struct HydrationControlPanel: View {
                         
             errorDisplay()
             suggestionDisplay()
-            HydrationMilestoneView(milestoneMessage: $milestoneMessage, isSpecialMilestone: $isSpecialMilestone)
         }
         .padding(.horizontal)
     }
@@ -126,45 +125,12 @@ struct HydrationControlPanel: View {
         errorMessage = nil
         streak = hydrationManager.streak
         await hydrationScheduler.rescheduleHydrationNotifications()
-        displayMilestoneMessage(newTotalIntake: todayIntake, lastMilestone: lastRecordedMilestone)
-
+        hydrationManager.milestoneManager.displayMilestoneMessage(
+            newTotal: hydrationManager.getTodayTotalOunces(),
+            lastMilestone: lastRecordedMilestone,
+            unit: "oz of water"
+        )
         selectedAmount = nil
         intakeAmount = ""
-    }
-    
-    // MARK: - Helper Function: Display Milestone Message
-    func displayMilestoneMessage(newTotalIntake: Double, lastMilestone: Double) {
-        let milestoneData = checkMilestones(newTotalIntake: newTotalIntake, lastMilestone: lastMilestone)
-        
-        if let message = milestoneData.message {
-            withAnimation {
-                self.milestoneMessage = message
-                self.isSpecialMilestone = milestoneData.isSpecial
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                withAnimation {
-                    self.milestoneMessage = nil
-                    self.isSpecialMilestone = false
-                }
-            }
-        }
-    }
-
-    // MARK: - Check Milestones
-    func checkMilestones(newTotalIntake: Double, lastMilestone: Double) -> (message: String?, isSpecial: Bool) {
-        var latestMessage: String?
-        var isSpecialMilestone = false
-
-        for milestone in stride(from: 20, through: newTotalIntake, by: 20) where milestone > lastMilestone {
-            if milestone == 60 && lastMilestone < 60 {
-                latestMessage = "🎉🎉 Amazing! You've reached 60 oz today! Keep up the great work! 🎉🎉"
-                isSpecialMilestone = true
-            } else {
-                latestMessage = "🎉 Great job! You've reached \(Int(milestone)) oz of water today!"
-                isSpecialMilestone = false
-            }
-        }
-
-        return (latestMessage, isSpecialMilestone)
     }
 }

--- a/Stanford360/Hydration/View/HydrationStreakView.swift
+++ b/Stanford360/Hydration/View/HydrationStreakView.swift
@@ -35,7 +35,7 @@ struct HydrationStreakView: View {
                 .padding(.horizontal, 8)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.orange.opacity(0.2))
+                        .fill(Color.white)
                         .shadow(radius: 1)
                 )
                 .transition(.scale)

--- a/Stanford360/Hydration/View/HydrationTodayView.swift
+++ b/Stanford360/Hydration/View/HydrationTodayView.swift
@@ -12,7 +12,7 @@ struct HydrationTodayView: View {
     @Environment(HydrationManager.self) private var hydrationManager
 
     var body: some View {
-        VStack(spacing: 10) {
+        ZStack {
             PercentageRing(
                 currentValue: Int(hydrationManager.getTodayTotalOunces()),
                 maxValue: 60,
@@ -26,10 +26,13 @@ struct HydrationTodayView: View {
             )
             .frame(height: 210)
             .padding(.top, 15)
-
+            
+            MilestoneMessageView(unit: "oz of water")
+                .environmentObject(hydrationManager.milestoneManager)
+                .offset(y: -100)
+            
             HydrationStreakView()
-            .frame(minHeight: 40)
-            .padding(.bottom, 10)
+            .offset(y: 110)
         }
     }
 }

--- a/Stanford360/Protein/Model/ProteinManager.swift
+++ b/Stanford360/Protein/Model/ProteinManager.swift
@@ -13,6 +13,7 @@ import Spezi
 @Observable
 class ProteinManager: Module, EnvironmentAccessible {
 	var meals: [Meal]
+    let milestoneManager = MilestoneManager()
     var todayMeals: [Meal] {
         let today = Calendar.current.startOfDay(for: Date())
         return mealsByDate[today] ?? []
@@ -62,6 +63,11 @@ class ProteinManager: Module, EnvironmentAccessible {
 	func getTotalProteinGrams(_ meals: [Meal]) -> Double {
 		meals.reduce(0) { $0 + $1.proteinGrams }
 	}
+    
+    func getLatestMilestone() -> Double {
+        let totalIntake = getTodayTotalGrams()
+        return milestoneManager.getLatestMilestone(total: totalIntake)
+    }
 	
 	// Add a new meal to the list
 //	func addMeal(name: String, proteinGrams: Double, imageURL: String? = nil, timestamp: Date = Date()) {

--- a/Stanford360/Protein/View/AddMealView.swift
+++ b/Stanford360/Protein/View/AddMealView.swift
@@ -354,6 +354,7 @@ extension AddMealView {
         isLoading = true
         defer { isLoading = false }
         var meal = Meal(name: mealName, proteinGrams: Double(proteinAmount) ?? 0)
+        let lastRecordedMilestone = proteinManager.getLatestMilestone()
         
 //        if let image = selectedImage {
 //            if let imageURL = await standard.uploadImageToFirebase(image, imageName: meal.id ?? UUID().uuidString) {
@@ -365,5 +366,10 @@ extension AddMealView {
         
 		proteinManager.meals.append(meal)
         await standard.storeMeal(meal/*, selectedImage: selectedImage*/)
+        proteinManager.milestoneManager.displayMilestoneMessage(
+                newTotal: proteinManager.getTodayTotalGrams(),
+                lastMilestone: lastRecordedMilestone,
+                unit: "grams of protein"
+            )
     }
 }

--- a/Stanford360/Protein/View/ProteinTodayView.swift
+++ b/Stanford360/Protein/View/ProteinTodayView.swift
@@ -14,20 +14,26 @@ import SwiftUI
 struct ProteinTodayView: View {
 	@Environment(ProteinManager.self) private var proteinManager
 	
-	var body: some View {
-		PercentageRing(
-			currentValue: Int(proteinManager.getTodayTotalGrams()),
-			maxValue: 60,
-			iconName: "fork.knife",
-			ringWidth: 25,
-			backgroundColor: Color.proteinColorBackground,
-			foregroundColors: [Color.proteinColor, Color.proteinColorGradient],
-			unitLabel: "grams",
-			iconSize: 13,
-			showProgressTextInCenter: true
-		)
-		.frame(maxHeight: 210)
-	}
+    var body: some View {
+        ZStack {
+            PercentageRing(
+                currentValue: Int(proteinManager.getTodayTotalGrams()),
+                maxValue: 60,
+                iconName: "fork.knife",
+                ringWidth: 25,
+                backgroundColor: Color.proteinColorBackground,
+                foregroundColors: [Color.proteinColor, Color.proteinColorGradient],
+                unitLabel: "grams",
+                iconSize: 13,
+                showProgressTextInCenter: true
+            )
+            .frame(maxHeight: 210)
+            
+            MilestoneMessageView(unit: "grams of protein")
+                .environmentObject(proteinManager.milestoneManager)
+                .offset(y: -100)
+        }
+    }
 }
 
 #Preview {

--- a/Stanford360/Shared/Components/MilestoneMessageView.swift
+++ b/Stanford360/Shared/Components/MilestoneMessageView.swift
@@ -8,21 +8,21 @@
 
 import SwiftUI
 
-struct HydrationMilestoneView: View {
-    @Binding var milestoneMessage: String?
-    @Binding var isSpecialMilestone: Bool
+struct MilestoneMessageView: View {
+    @EnvironmentObject var milestoneManager: MilestoneManager
+    let unit: String
 
     var body: some View {
-        if let message = milestoneMessage {
+        if let message = milestoneManager.milestoneMessage {
             Text(message)
-                .foregroundColor(isSpecialMilestone ? .orange : .blue)
+                .foregroundColor(milestoneManager.isSpecialMilestone ? .orange : .blue)
                 .font(.headline)
                 .multilineTextAlignment(.center)
                 .lineLimit(nil)
                 .padding(12)
                 .background(RoundedRectangle(cornerRadius: 10).fill(Color.white).shadow(radius: 2))
                 .transition(.scale)
-                .accessibilityIdentifier("milestoneMessageLabel")
+                .accessibilityIdentifier("\(unit)MilestoneMessageLabel")
         } else {
             EmptyView()
         }

--- a/Stanford360/Shared/Models/MilestoneManager.swift
+++ b/Stanford360/Shared/Models/MilestoneManager.swift
@@ -1,0 +1,78 @@
+//
+// This source file is part of the Stanford 360 based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+class MilestoneManager: ObservableObject {
+    @Published var milestoneMessage: String?
+    @Published var isSpecialMilestone: Bool = false
+
+    // MARK: - Check Milestones with Custom Unit
+    func checkMilestones(
+        newTotal: Double,
+        lastMilestone: Double,
+        unit: String,
+        milestoneInterval: Double = 20,
+        specialMilestone: Double = 60
+    ) -> (message: String?, isSpecial: Bool) {
+        var latestMessage: String?
+        var isSpecial = false
+
+        for milestone in stride(from: milestoneInterval, through: newTotal, by: milestoneInterval) where milestone > lastMilestone {
+            if milestone == specialMilestone && lastMilestone < specialMilestone {
+                latestMessage = "🎉🎉 Amazing! You've reached \(Int(specialMilestone)) \(unit) today! Keep up the great work! 🎉🎉"
+                isSpecial = true
+            } else {
+                latestMessage = "🎉 Great job! You've reached \(Int(milestone)) \(unit) today!"
+                isSpecial = false
+            }
+        }
+        return (latestMessage, isSpecial)
+    }
+
+    // MARK: - Display Milestone Message
+    @MainActor
+    func displayMilestoneMessage(
+        newTotal: Double,
+        lastMilestone: Double,
+        unit: String,
+        milestoneInterval: Double = 20,
+        specialMilestone: Double = 60
+    ) {
+        let milestoneData = checkMilestones(
+            newTotal: newTotal,
+            lastMilestone: lastMilestone,
+            unit: unit,
+            milestoneInterval: milestoneInterval,
+            specialMilestone: specialMilestone
+        )
+
+        if let message = milestoneData.message {
+            withAnimation {
+                self.milestoneMessage = message
+                self.isSpecialMilestone = milestoneData.isSpecial
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                withAnimation {
+                    self.milestoneMessage = nil
+                    self.isSpecialMilestone = false
+                }
+            }
+        }
+    }
+
+    // MARK: - Get Latest Milestone
+    func getLatestMilestone(total: Double, milestoneInterval: Double = 20) -> Double {
+        Double((Int(total) / Int(milestoneInterval)) * Int(milestoneInterval))
+    }
+}


### PR DESCRIPTION
# *Milestone Feature Refactor and Added to Protein View*

## :recycle: Current situation & Problem
Previously, the milestone tracking feature was only implemented for hydration and lacked a reusable structure. Protein tracking did not have a milestone message, and there was redundancy in the milestone-related logic across different views.


## :gear: Release Notes 
Refactored Milestone Logic:
Created a reusable MilestoneManager to handle milestone messages for hydration, protein, and future features.
Improved milestone message logic, allowing customization of unit types (e.g., oz of water, grams of protein).

Added Milestone Feature to Protein View:
The milestone message now appears in the Protein View when users log protein intake.
Uses MilestoneMessageView, ensuring a consistent user experience across hydration and protein tracking.

UI Improvements:
The milestone message now overlays the Percentage Ring at the top for both hydration and protein.


![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 13 32 37](https://github.com/user-attachments/assets/ad0e69d8-7865-4f52-a58e-55a1307685d9)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-06 at 13 30 39](https://github.com/user-attachments/assets/6c2187cf-5d92-4df1-81f0-407e35cbd098)


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
