### PR TITLE
refactor and update selector view

### DIFF
--- a/Stanford360/Hydration/View/HydrationAmountSelector.swift
+++ b/Stanford360/Hydration/View/HydrationAmountSelector.swift
@@ -12,7 +12,7 @@ struct HydrationAmountSelector: View {
     @Binding var selectedAmount: Double?
     @Binding var errorMessage: String?
 
-    let presetAmounts: [(icon: String, amount: Double)] = [
+    private let hydrationOptions: [(icon: String, amount: Double)] = [
         (icon: "small_mug", amount: 8.0),
         (icon: "large_mug", amount: 10.0),
         (icon: "medium_mug", amount: 12.0),
@@ -22,43 +22,11 @@ struct HydrationAmountSelector: View {
     ]
 
     var body: some View {
-        let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
-
-        LazyVGrid(columns: columns, spacing: 12) {
-            ForEach(presetAmounts, id: \.amount) { item in
-                VStack(spacing: 6) {
-                    Image(item.icon)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
-                        .frame(
-                            width: [16, 20, 32].contains(item.amount) ? 40 : 30,
-                            height: [16, 20, 32].contains(item.amount) ? 40 : 30
-                        )
-                        .clipped()
-                        .accessibilityLabel("\(Int(item.amount)) oz water")
-
-                    Text("\(Int(item.amount)) oz")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                }
-                .frame(width: 65, height: 65)
-                .padding()
-                .background(
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 12).fill(Color.white)
-                        if selectedAmount == item.amount {
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(Color.blue, lineWidth: 3)
-                        }
-                    }
-                )
-                .shadow(radius: 2)
-                .onTapGesture {
-                    selectedAmount = item.amount
-                    errorMessage = nil
-                }
-            }
-        }
-        .padding(.horizontal)
+        SelectorView(
+            selectedAmount: $selectedAmount,
+            errorMessage: $errorMessage,
+            options: hydrationOptions,
+            unit: "oz"
+        )
     }
 }

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -10,6 +10,16 @@
     "%lld" : {
 
     },
+    "%lld %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld %2$@"
+          }
+        }
+      }
+    },
     "%lld Day Streak" : {
 
     },
@@ -17,12 +27,6 @@
 
     },
     "%lld min" : {
-
-    },
-    "%lld oz" : {
-
-    },
-    "%lld oz water" : {
 
     },
     "%lld/%lld" : {

--- a/Stanford360/Shared/Components/SelectorView.swift
+++ b/Stanford360/Shared/Components/SelectorView.swift
@@ -1,0 +1,76 @@
+//
+// This source file is part of the Stanford 360 based on the Stanford Spezi Template Application project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct SelectorView: View {
+    @Binding var selectedAmount: Double?
+    @Binding var errorMessage: String?
+
+    let options: [(icon: String, amount: Double)]
+    let unit: String
+
+    private let columns = [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(options, id: \.amount) { item in
+                selectionItem(item)
+            }
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - Selection Item View
+    private func selectionItem(_ item: (icon: String, amount: Double)) -> some View {
+        VStack(spacing: 6) {
+            selectionIcon(item.icon, amount: item.amount)
+            selectionLabel(amount: item.amount)
+        }
+        .frame(width: 65, height: 65)
+        .padding()
+        .background(selectionBackground(item))
+        .shadow(radius: 2)
+        .onTapGesture {
+            selectedAmount = item.amount
+            errorMessage = nil
+        }
+    }
+
+    // MARK: - Selection Icon
+    private func selectionIcon(_ icon: String, amount: Double) -> some View {
+        Image(icon)
+            .resizable()
+            .renderingMode(.template)
+            .aspectRatio(contentMode: .fit)
+            .frame(width: [16, 20, 32].contains(amount) ? 40 : 30, height: [16, 20, 32].contains(amount) ? 40 : 30)
+            .clipped()
+            .accessibilityLabel("\(Int(amount)) \(unit)")
+    }
+
+    // MARK: - Selection Label
+    private func selectionLabel(amount: Double) -> some View {
+        Text("\(Int(amount)) \(unit)")
+            .font(.headline)
+            .foregroundColor(.primary)
+    }
+
+    // MARK: - Background and Selection State
+    private func selectionBackground(_ item: (icon: String, amount: Double)) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemBackground))
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color(.separator), lineWidth: 1)
+            if selectedAmount == item.amount {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.blue, lineWidth: 3)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# *Refactor and Update Selector View*

## :recycle: Current situation & Problem
The HydrationAmountSelector was previously designed specifically for selecting hydration intake, making it not reusable for other features such as activity tracking or protein intake logging. Additionally, the previous implementation had visual issues in dark mode.


## :gear: Release Notes 
Refactored AmountSelectorView to support hydration, activity, and protein selection with customizable units (oz, grams, minutes).
Fixed dark mode issues: Icons now adapt to dark mode using rendering mode and color adjustments.
Reduced code duplication by making the component configurable.

![Simulator Screenshot - iPhone 16 Pro - 2025-03-10 at 03 06 49](https://github.com/user-attachments/assets/226136c2-debe-41b5-825d-5d64faf3fe1d)
![Simulator Screenshot - iPhone 16 Pro - 2025-03-10 at 03 07 00](https://github.com/user-attachments/assets/bc8b700e-e8a6-4004-91f3-91ad906ec47b)


## :books: Documentation


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
