### PR TITLE
organize history tab views by date

### DIFF
--- a/Stanford360/Activity/View/ActivityHistoryView.swift
+++ b/Stanford360/Activity/View/ActivityHistoryView.swift
@@ -15,34 +15,38 @@ struct ActivityHistoryView: View {
 	@Environment(ActivityManager.self) private var activityManager
 	
 	var body: some View {
-		let activities = activityManager.activities
-		let reverseSortedActivities = activityManager.reverseSortActivitiesByDate(activities)
+		let activitiesByDate = activityManager.activitiesByDate
+		let dates = activitiesByDate.keys.sorted(by: >)
 		
-		if activities.isEmpty {
+		if activityManager.activities.isEmpty {
 			// todo - decompose into "empty state" component
 			List {
-				Text("No activities logged today")
+				Text("No activities logged")
 					.foregroundColor(.gray)
 					.padding()
 			}
 			.listStyle(PlainListStyle())
 		} else {
 			List {
-				ForEach(reverseSortedActivities) { activity in
-					ActivityCardView(activity: activity)
-						.simultaneousGesture(
-							DragGesture(minimumDistance: 5)
-								.onChanged { value in
-									let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-									let isQuickSwipe = abs(value.translation.width) < 20
-									
-									// If it's a quick, short horizontal swipe, let it through
-									// as it's likely attempting to access the swipe actions
-									if isHorizontalDrag && !isQuickSwipe {
-										// Consume the gesture to prevent TabView swiping
-									}
-								}
-						)
+				ForEach(dates, id: \.self) { date in
+					Section(header: Text(date.formattedRelative())) {
+						ForEach(activityManager.reverseSortActivitiesByDate(activitiesByDate[date] ?? [])) { activity in
+							ActivityCardView(activity: activity)
+								.simultaneousGesture(
+									DragGesture(minimumDistance: 5)
+										.onChanged { value in
+											let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
+											let isQuickSwipe = abs(value.translation.width) < 20
+											
+											// If it's a quick, short horizontal swipe, let it through
+											// as it's likely attempting to access the swipe actions
+											if isHorizontalDrag && !isQuickSwipe {
+												// Consume the gesture to prevent TabView swiping
+											}
+										}
+								)
+						}
+					}
 				}
 			}
 			.listStyle(PlainListStyle())

--- a/Stanford360/Hydration/View/HydrationHistoryView.swift
+++ b/Stanford360/Hydration/View/HydrationHistoryView.swift
@@ -15,34 +15,38 @@ struct HydrationHistoryView: View {
 	@Environment(HydrationManager.self) private var hydrationManager
 	
 	var body: some View {
-		let hydration = hydrationManager.hydration
-		let reverseSortedHydration = hydrationManager.reverseSortHydrationByDate(hydration)
+		let hydrationByDate = hydrationManager.hydrationByDate
+		let dates = hydrationByDate.keys.sorted(by: >)
 		
-		if hydration.isEmpty {
+		if hydrationManager.hydration.isEmpty {
 			// todo - decompose into "empty state" component
 			List {
-				Text("No hydration logged today")
+				Text("No hydration logged")
 					.foregroundColor(.gray)
 					.padding()
 			}
 			.listStyle(PlainListStyle())
 		} else {
 			List {
-				ForEach(reverseSortedHydration) { hydrationLog in
-					HydrationCardView(hydrationLog: hydrationLog)
-						.simultaneousGesture(
-							DragGesture(minimumDistance: 5)
-								.onChanged { value in
-									let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-									let isQuickSwipe = abs(value.translation.width) < 20
-									
-									// If it's a quick, short horizontal swipe, let it through
-									// as it's likely attempting to access the swipe actions
-									if isHorizontalDrag && !isQuickSwipe {
-										// Consume the gesture to prevent TabView swiping
-									}
-								}
-						)
+				ForEach(dates, id: \.self) { date in
+					Section(header: Text(date.formattedRelative())) {
+						ForEach(hydrationManager.reverseSortHydrationByDate(hydrationByDate[date] ?? [])) { hydrationLog in
+							HydrationCardView(hydrationLog: hydrationLog)
+								.simultaneousGesture(
+									DragGesture(minimumDistance: 5)
+										.onChanged { value in
+											let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
+											let isQuickSwipe = abs(value.translation.width) < 20
+											
+											// If it's a quick, short horizontal swipe, let it through
+											// as it's likely attempting to access the swipe actions
+											if isHorizontalDrag && !isQuickSwipe {
+												// Consume the gesture to prevent TabView swiping
+											}
+										}
+								)
+						}
+					}
 				}
 			}
 			.listStyle(PlainListStyle())

--- a/Stanford360/Protein/View/ProteinHistoryView.swift
+++ b/Stanford360/Protein/View/ProteinHistoryView.swift
@@ -14,44 +14,48 @@ import SwiftUI
 struct ProteinHistoryView: View {
 	@Environment(ProteinManager.self) private var proteinManager
 	
-    var body: some View {
-		let meals = proteinManager.meals
-		let reverseSortedMeals = proteinManager.reverseSortMealsByDate(meals)
+	var body: some View {
+		let mealsByDate = proteinManager.mealsByDate
+		let dates = mealsByDate.keys.sorted(by: >)
 		
-		if meals.isEmpty {
-				// todo - decompose into "empty state" component
-				List {
-					Text("No meals logged today")
-						.foregroundColor(.gray)
-						.padding()
-				}
-				.listStyle(PlainListStyle())
+		if proteinManager.meals.isEmpty {
+			// todo - decompose into "empty state" component
+			List {
+				Text("No meals logged")
+					.foregroundColor(.gray)
+					.padding()
+			}
+			.listStyle(PlainListStyle())
 		} else {
 			List {
-				ForEach(reverseSortedMeals) { meal in
-					NavigationLink(destination: MealDetailView(meal: meal)) {
-						ProteinCardView(meal: meal)
-					}
-					.simultaneousGesture(
-						DragGesture(minimumDistance: 5)
-							.onChanged { value in
-								let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-								let isQuickSwipe = abs(value.translation.width) < 20
-								
-								// If it's a quick, short horizontal swipe, let it through
-								// as it's likely attempting to access the swipe actions
-								if isHorizontalDrag && !isQuickSwipe {
-									// Consume the gesture to prevent TabView swiping
-								}
+				ForEach(dates, id: \.self) { date in
+					Section(header: Text(date.formattedRelative())) {
+						ForEach(proteinManager.reverseSortMealsByDate(mealsByDate[date] ?? [])) { meal in
+							NavigationLink(destination: MealDetailView(meal: meal)) {
+								ProteinCardView(meal: meal)
 							}
-					)
+							.simultaneousGesture(
+								DragGesture(minimumDistance: 5)
+									.onChanged { value in
+										let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
+										let isQuickSwipe = abs(value.translation.width) < 20
+										
+									// If it's a quick, short horizontal swipe, let it through
+										// as it's likely attempting to access the swipe actions
+										if isHorizontalDrag && !isQuickSwipe {
+											// Consume the gesture to prevent TabView swiping
+										}
+									}
+							)
+						}
+					}
 				}
 			}
 			.listStyle(PlainListStyle())
 		}
-    }
+	}
 }
 
 #Preview {
-    ProteinHistoryView()
+	ProteinHistoryView()
 }

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -10,10 +10,23 @@
     "%lld" : {
 
     },
+    "%lld %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$lld %2$@"
+          }
+        }
+      }
+    },
     "%lld g" : {
 
     },
     "%lld min" : {
+
+    },
+    "%lld oz" : {
 
     },
     "%lld/%lld" : {
@@ -188,9 +201,6 @@
 
     },
     "Dashboard" : {
-
-    },
-    "Day" : {
 
     },
     "Delete" : {
@@ -448,19 +458,10 @@
     "Log your water intake" : {
 
     },
-    "Meal Recommendations" : {
-
-    },
     "Metric" : {
 
     },
     "Minutes" : {
-
-    },
-    "Month" : {
-
-    },
-    "Monthly Protein Intake" : {
 
     },
     "Move. Drink. Eat. Can you score 360 today? 🎯🏆" : {
@@ -482,16 +483,16 @@
         }
       }
     },
-    "No activities logged today" : {
+    "No activities logged" : {
 
     },
-    "No hydration logged today" : {
+    "No hydration logged" : {
 
     },
     "No Image Available" : {
 
     },
-    "No meals logged today" : {
+    "No meals logged" : {
 
     },
     "No tasks" : {
@@ -759,9 +760,6 @@
 
     },
     "Weekly Check-In" : {
-
-    },
-    "Weekly Protein Intake" : {
 
     },
     "Weight (lbs)" : {

--- a/Stanford360/Shared/Utilities/Date+Utilities.swift
+++ b/Stanford360/Shared/Utilities/Date+Utilities.swift
@@ -1,0 +1,37 @@
+//
+//  Date+Utilities.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 3/10/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+extension Date {
+	func formattedRelative() -> String {
+		let calendar = Calendar.current
+		
+		if calendar.isDateInToday(self) {
+			return "Today"
+		} else if calendar.isDateInYesterday(self) {
+			return "Yesterday"
+		} else {
+			let formatter = DateFormatter()
+			
+			let currentYear = calendar.component(.year, from: Date())
+			let dateYear = calendar.component(.year, from: self)
+			
+			if dateYear == currentYear {
+				formatter.dateFormat = "EEE MMM d" // e.g., "Mon Mar 10"
+			} else {
+				formatter.dateFormat = "EEE MMM d, yyyy" // e.g., "Wed Mar 10, 2025"
+			}
+			
+			return formatter.string(from: self)
+		}
+	}
+}


### PR DESCRIPTION
# *organize history tab views by date*

## :recycle: Current situation & Problem
* Activity, Hydration, and Protein's `History` Tab View's are hard to understand since they render all trackable items with no organization


## :gear: Release Notes 
* Organizes the trackable items' cards into sections by date

<img width="300" alt="Screenshot 2025-03-10 at 5 34 48 PM" src="https://github.com/user-attachments/assets/e6e1d558-340c-407b-a9c0-8f4efd11305f" />
<img width="300" alt="Screenshot 2025-03-10 at 5 34 45 PM" src="https://github.com/user-attachments/assets/8bd742a4-88f5-4206-bd8f-d63afa30fdaa" />
<img width="300" alt="Screenshot 2025-03-10 at 5 34 41 PM" src="https://github.com/user-attachments/assets/ab33950d-7341-4249-81e7-f569ca45a2c2" />


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
