### PR TITLE
fix activity view

### DIFF
--- a/Stanford360.xcodeproj/project.pbxproj
+++ b/Stanford360.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		2FE5DCB129EE6107004B9AB4 /* AccountOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */; };
 		2FF53D8D2A8729D600042B76 /* Stanford360Standard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF53D8C2A8729D600042B76 /* Stanford360Standard.swift */; };
 		45E2F1172D82619E0097C339 /* MilestoneTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E2F1162D8261980097C339 /* MilestoneTests.swift */; };
-		45E038232D503C0F009D07E2 /* HydrationViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E038222D503BFA009D07E2 /* HydrationViewTests.swift */; };
 		4D2965D82D7A8084000664B4 /* SpeziLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D2965D72D7A8084000664B4 /* SpeziLLM */; };
 		4D2965DA2D7A8084000664B4 /* SpeziLLMFog in Frameworks */ = {isa = PBXBuildFile; productRef = 4D2965D92D7A8084000664B4 /* SpeziLLMFog */; };
 		4D2965DC2D7A8084000664B4 /* SpeziLLMLocal in Frameworks */ = {isa = PBXBuildFile; productRef = 4D2965DB2D7A8084000664B4 /* SpeziLLMLocal */; };
@@ -139,7 +138,6 @@
 		2FE5DCAC29EE6107004B9AB4 /* AccountOnboarding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountOnboarding.swift; sourceTree = "<group>"; };
 		2FF53D8C2A8729D600042B76 /* Stanford360Standard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Stanford360Standard.swift; sourceTree = "<group>"; };
 		45E2F1162D8261980097C339 /* MilestoneTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneTests.swift; sourceTree = "<group>"; };
-		45E038222D503BFA009D07E2 /* HydrationViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HydrationViewTests.swift; sourceTree = "<group>"; };
 		4FC5EF032D78162800BFDFFD /* KidsOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KidsOnboarding.swift; sourceTree = "<group>"; };
 		4FCAD0582D5AAD20007324A6 /* ActivityViewUITest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityViewUITest.swift; sourceTree = "<group>"; };
 		5680DD3D2AB8CD84004E6D4A /* ContributionsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContributionsTest.swift; sourceTree = "<group>"; };

--- a/Stanford360/Activity/Model/ActivityManager.swift
+++ b/Stanford360/Activity/Model/ActivityManager.swift
@@ -85,17 +85,6 @@ class ActivityManager: Module, EnvironmentAccessible {
         minutes * 100
     }
     
-    func triggerMotivation() -> String {
-        if getTodayTotalMinutes() >= 60 {
-            return "🎉 Amazing! You've reached your daily goal of 60 minutes!"
-        } else if getTodayTotalMinutes() > 0 {
-            let remainingMinutes = 60 - getTodayTotalMinutes()
-            return "Keep going! Only \(remainingMinutes) more minutes to reach today's goal! 🚀"
-        } else {
-            return "Start your activity today and move towards your goal! 💪"
-        }
-    }
-    
     func saveToStorage() {
         do {
             let data = try JSONEncoder().encode(activities)

--- a/Stanford360/Activity/Model/ActivityScheduler.swift
+++ b/Stanford360/Activity/Model/ActivityScheduler.swift
@@ -29,6 +29,7 @@ extension Stanford360Scheduler {
 		}
 	}
 	
+	// periphery:ignore
 	/// "delete" notification occurence of belowHalfActivity5PMNotificationTaskID by marking it complete such that it doesn't fire
 	@MainActor
 	func deleteNotificationOccurence(taskIds: [String]) {
@@ -46,6 +47,7 @@ extension Stanford360Scheduler {
 		}
 	}
 	
+	// periphery:ignore
 	@MainActor
 	func handleOnLoggedBefore5PM(_ surpassed30Minutes: Bool, _ surpassed60Minutes: Bool) {
 		if surpassed30Minutes || surpassed60Minutes {
@@ -87,6 +89,7 @@ extension Stanford360Scheduler {
 		}
 	}
 	
+	// periphery:ignore
 	@MainActor
 	func handleOnLoggedAtOrAfter5PM(_ surpassed30Minutes: Bool, _ surpassed60Minutes: Bool) {
 		let potentialEventIDs = [
@@ -128,6 +131,7 @@ extension Stanford360Scheduler {
 		}
 	}
 	
+	// periphery:ignore
 	@MainActor
 	func handleNotificationsOnLoggedActivity(prevActivityMinutes: Int, newActivityMinutes: Int) async {
 		let now = Date()

--- a/Stanford360/Activity/View/ActivityAddView.swift
+++ b/Stanford360/Activity/View/ActivityAddView.swift
@@ -13,119 +13,70 @@ import SwiftUI
 
 struct ActivityAddView: View {
 	@Environment(ActivityManager.self) private var activityManager
-    @Environment(Stanford360Standard.self) private var standard
-    @Environment(Stanford360Scheduler.self) var scheduler
-    
-    // Activity properties that can be initialized for editing
-    @State private var activeMinutes: String
-    @State private var selectedActivity: String
-    @State private var selectedDate: Date
-    @State private var showingDateError = false
-    @State private var showingAddActivity = false
-    private var activityId: String?
 	
-    var body: some View {
-        ZStack {
-            VStack(spacing: 20) {
-                PercentageRing(
-                    currentValue: activityManager.getTodayTotalMinutes(),
-                    maxValue: 60,
-                    iconName: "figure.walk",
-                    ringWidth: 25,
-                    backgroundColor: Color.activityColorBackground,
-                    foregroundColors: [Color.activityColor, Color.activityColorGradient],
-                    unitLabel: "minutes",
-                    iconSize: 13,
-                    showProgressTextInCenter: true
-                )
-                .frame(width: 210, height: 210) // Fixed dimensions
-                .padding(.top, 30)
-                
-                Text.goalMessage(current: Double(activityManager.getTodayTotalMinutes()), goal: 60, unit: "min")
-                    .padding(.top, 10)
-                
-                // Activity input components
-                ActivityPickerView(selectedActivity: $selectedActivity)
-                    .padding(.top, 20)
-                
-                saveNewActivityButton(showingAddActivity: $showingAddActivity)
-                    .padding(.bottom, 30)
-            }
-            .padding(.horizontal)
-            
-            MilestoneMessageView(unit: "minutes of activity")
-                .environmentObject(activityManager.milestoneManager)
-                .offset(y: -250)
-        }
-        .sheet(isPresented: $showingAddActivity) {
-            AddActivitySheet(selectedActivity: selectedActivity)
-        }
-    }
-    
-    private var saveButtonView: some View {
-        ActionButton(
-            title: "Save My Activity! 🌟",
-            action: {
-                Task {
-                    await saveNewActivity()
-                }
-            },
-            isDisabled: activeMinutes.isEmpty
-        )
-    }
-    
-    // MARK: - Initializers
-    init(selectedActivity: String = "Walking", activeMinutes: String = "", selectedDate: Date = Date()) {
-        self._selectedActivity = State(initialValue: selectedActivity)
-        self._activeMinutes = State(initialValue: activeMinutes)
-        self._selectedDate = State(initialValue: selectedDate)
-        self.activityId = nil
-    }
-    
-    init(activity: Activity) {
-        self._activeMinutes = State(initialValue: "\(activity.activeMinutes)")
-        self._selectedActivity = State(initialValue: activity.activityType)
-        self._selectedDate = State(initialValue: activity.date)
-        self.activityId = activity.id
-    }
-    
-    private func saveNewActivity() async {
-        let minutes = Int(activeMinutes) ?? 0
-        let estimatedSteps = activityManager.getStepsFromMinutes(minutes)
-        
-        let newActivity = Activity(
-            date: Date(),
-            steps: estimatedSteps,
-            activeMinutes: minutes,
-            activityType: selectedActivity
-        )
-        
-        let prevActivityMinutes = activityManager.getTodayTotalMinutes()
-        let lastRecordedMilestone = activityManager.getLatestMilestone()
-        activityManager.activities.append(newActivity)
-        let activityMinutes = activityManager.getTodayTotalMinutes()
-	let updatedStreak = activityManager.streak
-        await standard.addActivityToFirestore(newActivity)
-        await scheduler.handleNotificationsOnLoggedActivity(prevActivityMinutes: prevActivityMinutes, newActivityMinutes: activityMinutes)
-        activityManager.milestoneManager.displayMilestoneMessage(
-		newTotal: Double(activityManager.getTodayTotalMinutes()),
-		lastMilestone: lastRecordedMilestone,
-		unit: "minutes of activity",
-		streak: updatedStreak
-        )
-    }
-    
-    func saveNewActivityButton(showingAddActivity: Binding<Bool>) -> some View {
-        SaveActivityButton(
-            showingAddActivity: showingAddActivity,
-            selectedActivity: showingAddActivity.wrappedValue ? "Walking" : nil,
-            minutes: showingAddActivity.wrappedValue ? "0" : nil
-        )
-    }
+	// Activity properties that can be initialized for editing
+	@State private var activeMinutes: String
+	@State private var selectedActivity: String
+	@State private var selectedDate: Date
+	@State private var showingAddActivity = false
+	
+	var body: some View {
+		ZStack {
+			VStack(spacing: 20) {
+				PercentageRing(
+					currentValue: activityManager.getTodayTotalMinutes(),
+					maxValue: 60,
+					iconName: "figure.walk",
+					ringWidth: 25,
+					backgroundColor: Color.activityColorBackground,
+					foregroundColors: [Color.activityColor, Color.activityColorGradient],
+					unitLabel: "minutes",
+					iconSize: 13,
+					showProgressTextInCenter: true
+				)
+				.frame(height: 210)
+				.padding(.top, 30)
+				
+				Text.goalMessage(current: Double(activityManager.getTodayTotalMinutes()), goal: 60, unit: "min")
+					.padding(.top, 10)
+				
+				// Activity input components
+				ActivityPickerView(selectedActivity: $selectedActivity)
+					.padding(.top, 20)
+				
+				HStack {
+					saveNewActivityButton(showingAddActivity: $showingAddActivity)
+					
+					ActivityRecallButton()
+				}
+			}
+			.padding(.horizontal)
+			
+			MilestoneMessageView(unit: "minutes of activity")
+				.environmentObject(activityManager.milestoneManager)
+				.offset(y: -250)
+		}
+		.sheet(isPresented: $showingAddActivity) {
+			AddActivitySheet(selectedActivity: selectedActivity)
+		}
+	}
+	
+	// MARK: - Initializers
+	init(selectedActivity: String = "Walking", activeMinutes: String = "", selectedDate: Date = Date()) {
+		self._selectedActivity = State(initialValue: selectedActivity)
+		self._activeMinutes = State(initialValue: activeMinutes)
+		self._selectedDate = State(initialValue: selectedDate)
+	}
+	
+	func saveNewActivityButton(showingAddActivity: Binding<Bool>) -> some View {
+		SaveActivityButton(
+			showingAddActivity: showingAddActivity
+		)
+	}
 }
 
 #Preview {
 	@Previewable @State var activityManager = ActivityManager(activities: activitiesData)
-    ActivityAddView()
+	ActivityAddView()
 		.environment(activityManager)
 }

--- a/Stanford360/Activity/View/ActivityCardView.swift
+++ b/Stanford360/Activity/View/ActivityCardView.swift
@@ -12,61 +12,25 @@ import SwiftUI
 
 struct ActivityCardView: View {
     let activity: Activity
-    @Environment(ActivityManager.self) private var activityManager
-    @Environment(Stanford360Standard.self) private var standard
-    @State private var showingAddActivitySheet = false
-    @State private var isPerformingAction = false
 
     var body: some View {
         HStack {
             // Activity Type with Emoji
             Text(activity.activityType)
-                .font(.title3.bold())
+				.font(.system(size: 20))
+				.foregroundColor(.textSecondary)
             
             Spacer()
             
             // Minutes with emphasis
             Text("\(activity.activeMinutes) min")
-                .font(.title3)
-                .foregroundStyle(.blue)
+				.font(.system(size: 20))
+				.foregroundColor(Color.activityColor)
         }
-        // .background(
-        //     RoundedRectangle(cornerRadius: 12)
-        //         .fill(Color.white)
-        //         .shadow(radius: 2)
-        // )
         .padding(16)
 		.background(Color.cardBackground)
 		.cornerRadius(15)
 		.shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 4)
-        .swipeActions(edge: .leading, allowsFullSwipe: true) {
-            Button {
-                showingAddActivitySheet = true
-            } label: {
-                Label("Edit", systemImage: "pencil")
-            }
-            .tint(.blue)
-            .disabled(isPerformingAction)
-        }
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            Button(role: .destructive) {
-                isPerformingAction = true
-                Task {
-                    await standard.deleteActivity(activity)
-                    var updatedActivities = activityManager.activities
-                    updatedActivities.removeAll { $0.id == activity.id }
-                    activityManager.activities = updatedActivities
-                    isPerformingAction = false
-                }
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-            .disabled(isPerformingAction)
-        }
-        .sheet(isPresented: $showingAddActivitySheet) {
-            // Use the AddActivitySheet with the activity for editing
-            AddActivitySheet(activity: activity)
-        }
     }
 }
 

--- a/Stanford360/Activity/View/ActivityComponentsView.swift
+++ b/Stanford360/Activity/View/ActivityComponentsView.swift
@@ -83,43 +83,6 @@ struct ActivityPickerView: View {
     }
 }
 
-// MARK: - ActivityButtonView
-struct ActivityButtonView: View {
-    let activityName: String
-    let iconName: String
-    @Binding var selectedActivity: String
-    
-    var body: some View {
-        VStack(spacing: 6) {
-            Image(systemName: iconName)
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 40, height: 40)
-                .foregroundColor(.blue) // Change color as needed
-                .accessibilityLabel(activityName)
-
-            Text(activityName)
-                .font(.subheadline)
-                .foregroundColor(.primary)
-        }
-        .frame(width: 65, height: 65)
-        .padding()
-        .background(
-            ZStack {
-                RoundedRectangle(cornerRadius: 12).fill(Color.white)
-                if selectedActivity == activityName {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.blue, lineWidth: 3)
-                }
-            }
-        )
-        .shadow(radius: 2)
-        .onTapGesture {
-            selectedActivity = activityName
-        }
-    }
-}
-
 // MARK: - DatePickerView
 struct DatePickerView: View {
     @Binding var selectedDate: Date
@@ -225,9 +188,6 @@ struct ActionButton: View {
 
 struct SaveActivityButton: View {
     @Binding var showingAddActivity: Bool
-    var selectedActivity: String?
-    var minutes: String?
-    @State private var errorMessage: String?
     
     var body: some View {
         VStack(spacing: 10) {

--- a/Stanford360/Activity/View/ActivityHistoryView.swift
+++ b/Stanford360/Activity/View/ActivityHistoryView.swift
@@ -32,19 +32,7 @@ struct ActivityHistoryView: View {
 					Section(header: Text(date.formattedRelative())) {
 						ForEach(activityManager.reverseSortActivitiesByDate(activitiesByDate[date] ?? [])) { activity in
 							ActivityCardView(activity: activity)
-								.simultaneousGesture(
-									DragGesture(minimumDistance: 5)
-										.onChanged { value in
-											let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-											let isQuickSwipe = abs(value.translation.width) < 20
-											
-											// If it's a quick, short horizontal swipe, let it through
-											// as it's likely attempting to access the swipe actions
-											if isHorizontalDrag && !isQuickSwipe {
-												// Consume the gesture to prevent TabView swiping
-											}
-										}
-								)
+								.listRowSeparator(.hidden)
 						}
 					}
 				}

--- a/Stanford360/Activity/View/ActivityRecallButton.swift
+++ b/Stanford360/Activity/View/ActivityRecallButton.swift
@@ -1,0 +1,41 @@
+//
+//  ActivityRecallButton.swift
+//  Stanford360
+//
+//  Created by Kelly Bonilla Guzmán on 3/17/25.
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+struct ActivityRecallButton: View {
+	@Environment(ActivityManager.self) private var activityManager
+	@Environment(Stanford360Standard.self) private var standard
+	
+	var body: some View {
+		Button(action: {
+			Task {
+				if let activity = activityManager.activities.last {
+					await standard.deleteActivity(activity)
+					var updatedActivities = activityManager.activities
+					updatedActivities.removeLast(1)
+					activityManager.activities = updatedActivities
+				}
+			}
+		}) {
+			Image(systemName: "arrow.uturn.backward.circle.fill")
+				.font(.system(size: 40))
+				.foregroundColor(.red)
+				.accessibilityLabel("Undo last activity log")
+		}
+		.disabled(activityManager.getTodayTotalMinutes() == 0)
+	}
+}
+
+
+#Preview {
+	ActivityRecallButton()
+}

--- a/Stanford360/Activity/View/AddActivitySheetView.swift
+++ b/Stanford360/Activity/View/AddActivitySheetView.swift
@@ -15,7 +15,7 @@ struct AddActivitySheet: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(Stanford360Standard.self) private var standard
     @Environment(ActivityManager.self) private var activityManager
-    @Environment(Stanford360Scheduler.self) var scheduler
+//    @Environment(Stanford360Scheduler.self) var scheduler
     
     // Activity properties that can be initialized for editing
     @State private var activeMinutes: String
@@ -63,13 +63,6 @@ struct AddActivitySheet: View {
             saveButtonView
             Spacer()
         }
-    }
-    
-    private var headerView: some View {
-        Text(isEditing ? "Edit Your Activity! 📝" : "Add Your Activity! 🎯")
-            .font(.title)
-            .bold()
-            .padding(.top)
     }
     
     private var saveButtonView: some View {
@@ -124,14 +117,14 @@ struct AddActivitySheet: View {
             activityType: selectedActivity
         )
         
-        let prevActivityMinutes = activityManager.getTodayTotalMinutes()
+//        let prevActivityMinutes = activityManager.getTodayTotalMinutes()
         let lastRecordedMilestone = activityManager.getLatestMilestone()
         activityManager.activities.append(newActivity)
       
-        let activityMinutes = activityManager.getTodayTotalMinutes()
+//        let activityMinutes = activityManager.getTodayTotalMinutes()
         let updatedStreak = activityManager.streak
         await standard.addActivityToFirestore(newActivity)
-        await scheduler.handleNotificationsOnLoggedActivity(prevActivityMinutes: prevActivityMinutes, newActivityMinutes: activityMinutes)
+//        await scheduler.handleNotificationsOnLoggedActivity(prevActivityMinutes: prevActivityMinutes, newActivityMinutes: activityMinutes)
         activityManager.milestoneManager.displayMilestoneMessage(
             newTotal: Double(activityManager.getTodayTotalMinutes()),
             lastMilestone: lastRecordedMilestone,

--- a/Stanford360/Hydration/View/HydrationCardView.swift
+++ b/Stanford360/Hydration/View/HydrationCardView.swift
@@ -17,13 +17,14 @@ struct HydrationCardView: View {
 	var body: some View {
 		HStack {
 			Text("Water")
-				.font(.title3.bold())
+				.font(.system(size: 20))
+				.foregroundColor(.textSecondary)
 			
 			Spacer()
 			
 			Text("\(Int(hydrationLog.hydrationOunces)) oz")
-				.font(.title3)
-				.foregroundStyle(.blue)
+				.font(.system(size: 20))
+				.foregroundColor(Color.hydrationColor)
 		}
 		.padding(16)
 		.background(Color.cardBackground)

--- a/Stanford360/Hydration/View/HydrationControlPanel.swift
+++ b/Stanford360/Hydration/View/HydrationControlPanel.swift
@@ -50,7 +50,7 @@ struct HydrationControlPanel: View {
                 await logWaterIntake()
             }
         }) {
-            Text("Log Water Intake")
+            Text("Save My Water! 🌟")
                 .fontWeight(.bold)
                 .frame(maxWidth: .infinity)
                 .padding()
@@ -70,7 +70,7 @@ struct HydrationControlPanel: View {
         }
         .padding(.horizontal)
         .accessibilityIdentifier("logWaterIntakeButton")
-        .accessibilityLabel("Log your water intake")
+        .accessibilityLabel("Save My Water! 🌟")
     }
 
     // MARK: - Error Display

--- a/Stanford360/Hydration/View/HydrationHistoryView.swift
+++ b/Stanford360/Hydration/View/HydrationHistoryView.swift
@@ -33,19 +33,7 @@ struct HydrationHistoryView: View {
 					Section(header: Text(date.formattedRelative())) {
 						ForEach(hydrationManager.reverseSortHydrationByDate(hydrationByDate[date] ?? [])) { hydrationLog in
 							HydrationCardView(hydrationLog: hydrationLog)
-								.simultaneousGesture(
-									DragGesture(minimumDistance: 5)
-										.onChanged { value in
-											let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-											let isQuickSwipe = abs(value.translation.width) < 20
-											
-											// If it's a quick, short horizontal swipe, let it through
-											// as it's likely attempting to access the swipe actions
-											if isHorizontalDrag && !isQuickSwipe {
-												// Consume the gesture to prevent TabView swiping
-											}
-										}
-								)
+								.listRowSeparator(.hidden)
 						}
 					}
 				}

--- a/Stanford360/Protein/Service/FirebaseManager.swift
+++ b/Stanford360/Protein/Service/FirebaseManager.swift
@@ -39,6 +39,7 @@ extension Stanford360Standard {
         }
     }
     
+	// periphery:ignore
     func deleteMealByID(byID id: String) async {
         do {
             let userDocRef = try await configuration.userDocumentReference

--- a/Stanford360/Protein/View/ProteinAddView.swift
+++ b/Stanford360/Protein/View/ProteinAddView.swift
@@ -30,7 +30,7 @@ struct ProteinAddView: View {
                     iconSize: 13,
                     showProgressTextInCenter: true
                 )
-                .frame(maxHeight: 210)
+                .frame(height: 210)
                 .padding(.top, 30)
                 
                 Text.goalMessage(current: proteinManager.getTodayTotalGrams(), goal: 60, unit: "g")

--- a/Stanford360/Protein/View/ProteinCardView.swift
+++ b/Stanford360/Protein/View/ProteinCardView.swift
@@ -12,43 +12,24 @@
 import SwiftUI
 
 struct ProteinCardView: View {
-    @Environment(Stanford360Standard.self) private var standard
-    @Environment(ProteinManager.self) private var proteinManager
-    
 	let meal: Meal
 	
 	var body: some View {
 		HStack {
 			Text(meal.name)
-				.font(.title3.bold())
+				.font(.system(size: 20))
+				.foregroundColor(.textSecondary)
 			
 			Spacer()
 			
 			Text("\(Int(meal.proteinGrams)) g")
-				.font(.title3)
-				.foregroundStyle(.blue)
+				.font(.system(size: 20))
+				.foregroundColor(Color.proteinColor)
 		}
-		// .background(
-		//     RoundedRectangle(cornerRadius: 12)
-		//         .fill(Color.white)
-		//         .shadow(radius: 2)
-		// )
 		.padding(16)
 		.background(Color.cardBackground)
 		.cornerRadius(15)
 		.shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 4)
-        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-            Button(role: .destructive) {
-                Task {
-                    await standard.deleteMealByID(byID: meal.id ?? "")
-                    var updatedMeals = proteinManager.meals
-                    updatedMeals.removeAll { $0.id == meal.id }
-                    proteinManager.meals = updatedMeals
-                }
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
-        }
 	}
 }
 

--- a/Stanford360/Protein/View/ProteinHistoryView.swift
+++ b/Stanford360/Protein/View/ProteinHistoryView.swift
@@ -34,19 +34,7 @@ struct ProteinHistoryView: View {
 							NavigationLink(destination: MealDetailView(meal: meal)) {
 								ProteinCardView(meal: meal)
 							}
-							.simultaneousGesture(
-								DragGesture(minimumDistance: 5)
-									.onChanged { value in
-										let isHorizontalDrag = abs(value.translation.width) > abs(value.translation.height)
-										let isQuickSwipe = abs(value.translation.width) < 20
-										
-									// If it's a quick, short horizontal swipe, let it through
-										// as it's likely attempting to access the swipe actions
-										if isHorizontalDrag && !isQuickSwipe {
-											// Consume the gesture to prevent TabView swiping
-										}
-									}
-							)
+							.listRowSeparator(.hidden)
 						}
 					}
 				}

--- a/Stanford360/Resources/Localizable.xcstrings
+++ b/Stanford360/Resources/Localizable.xcstrings
@@ -218,13 +218,7 @@
     "Dashboard" : {
 
     },
-    "Delete" : {
-
-    },
     "Don't forget your 60 minutes of daily activity!" : {
-
-    },
-    "Edit" : {
 
     },
     "Edit Your Activity! 📝" : {
@@ -464,13 +458,7 @@
         }
       }
     },
-    "Log Water Intake" : {
-
-    },
     "Log Weight" : {
-
-    },
-    "Log your water intake" : {
 
     },
     "Metric" : {
@@ -615,6 +603,9 @@
     "Save My Activity! 🌟" : {
 
     },
+    "Save My Water! 🌟" : {
+
+    },
     "Save your activity" : {
 
     },
@@ -755,6 +746,9 @@
     "Tracker Section" : {
 
     },
+    "Undo last activity log" : {
+
+    },
     "Unsupported Event" : {
       "localizations" : {
         "en" : {
@@ -832,12 +826,6 @@
           }
         }
       }
-    },
-    "What did you do?" : {
-
-    },
-    "When did you do it?" : {
-
     },
     "You need %@ %@ more to reach your goal!" : {
       "localizations" : {

--- a/Stanford360/Schedule/Stanford360Scheduler.swift
+++ b/Stanford360/Schedule/Stanford360Scheduler.swift
@@ -27,11 +27,16 @@ final class Stanford360Scheduler: Module, DefaultInitializable, EnvironmentAcces
 	internal let sundayWeightNotificationTaskID = "sunday-weight-notification"
 	
 	internal let belowHalfActivity5PMNotificationTaskID = "below-half-activity-5pm-notif"
+	// periphery:ignore
 	internal let halfActivity5PMNotificationTaskID = "half-activity-5pm-notif"
+	// periphery:ignore
 	internal let fullActivity5PMNotificationTaskID = "full-activity-5pm-notif"
+	// periphery:ignore
 	internal let halfActivityImmediateNotificationTaskID = "half-activity-immediate-notif"
+	// periphery:ignore
 	internal let fullActivityImmediateNotificationTaskID = "full-activity-immediate-notif"
 		
+	// periphery:ignore
 	internal let dateRange1Day: Range<Date> = Date()..<Date().addingTimeInterval(60 * 60 * 24 * 1)
 
     init() {}


### PR DESCRIPTION
# *fix activity view*

## :recycle: Current situation & Problem
- App crashes when logging over 30 or 60 minutes of activity
- History tab views' cards' text can't be seen in dark mode
- History tab views' cards' swipe actions overridden by tab views' swipe switch
- Lots of unused code


## :gear: Release Notes 
- Resolves app crash
- Ensures history tab views' cards' text can be seen in dark mode
- Removes history tab views' swipe actions and introduces a recall button to the activity view instead
- Cleans up codebase


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
