### PR TITLE
back to swiping between activity tabs

### DIFF
--- a/Stanford360/Activity/View/ActivityAddView.swift
+++ b/Stanford360/Activity/View/ActivityAddView.swift
@@ -40,21 +40,15 @@ struct ActivityAddView: View {
 				Text.goalMessage(current: Double(activityManager.getTodayTotalMinutes()), goal: 60, unit: "min")
 					.padding(.top, 10)
 
-				Spacer()
-				
-				VStack {
-					// Activity input components
-					ActivityPickerView(selectedActivity: $selectedActivity)
-						.padding()
-					
-					HStack {
-						saveNewActivityButton(showingAddActivity: $showingAddActivity)
-						
-						ActivityRecallButton()
-						.offset(x: -10)
-					}
+				// Activity input components
+				ActivityPickerView(selectedActivity: $selectedActivity)
+					.padding(.top, 20)
+
+				HStack {
+					saveNewActivityButton(showingAddActivity: $showingAddActivity)
+
+					ActivityRecallButton()
 				}
-				.padding(.bottom, 30)
 			}
 			.padding(.horizontal)
 			

--- a/Stanford360/Activity/View/ActivityTabView.swift
+++ b/Stanford360/Activity/View/ActivityTabView.swift
@@ -17,20 +17,15 @@ struct ActivityTabView: View {
 	var body: some View {
 		VStack {
 			TrackerSegmentedPicker(selectedTrackerSection: $selectedTrackerSection)
-			
-			Group {
-				switch selectedTrackerSection {
-				case .add:
-					ActivityAddView()
-				case .history:
-					ActivityHistoryView()
-				case .discover:
-					ActivityDiscoverView()
-				}
+
+			TabView(selection: $selectedTrackerSection) {
+				ActivityAddView().tag(TrackerSection.add)
+				ActivityHistoryView().tag(TrackerSection.history)
+				ActivityDiscoverView().tag(TrackerSection.discover)
 			}
+			.tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
 		}
-		.frame(maxHeight: .infinity, alignment: .top)
-	}
+    }
 }
 
 #Preview {


### PR DESCRIPTION
# *Back to swiping between activity tabs*

## :recycle: Current situation & Problem
UI bug in add activity page
inconsistency between swiping/no swiping between tabs for hydration, activity, protein


## :gear: Release Notes 
correct bug
swiping allowed between tabs for activity

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
